### PR TITLE
Fixes service alert nil description

### DIFF
--- a/OBAKit/Controls/ListKit/SectionDataBuilders.swift
+++ b/OBAKit/Controls/ListKit/SectionDataBuilders.swift
@@ -29,7 +29,10 @@ extension SectionDataBuilders where Self: AppContext {
         var sections = [MessageSectionData]()
         for serviceAlert in Set(alerts).allObjects.sorted(by: { $0.createdAt > $1.createdAt }) {
             let formattedDate = application.formatters.shortDateTimeFormatter.string(from: serviceAlert.createdAt)
-            let message = MessageSectionData(author: Strings.serviceAlert, date: formattedDate, subject: serviceAlert.summary.value, summary: serviceAlert.situationDescription.value) { [weak self] _ in
+            let message = MessageSectionData(author: Strings.serviceAlert,
+                                             date: formattedDate,
+                                             subject: serviceAlert.summary.value,
+                                             summary: serviceAlert.situationDescription?.value) { [weak self] _ in
                 guard let self = self else { return }
                 let serviceAlertController = ServiceAlertViewController(serviceAlert: serviceAlert, application: self.application)
                 self.application.viewRouter.navigate(to: serviceAlertController, from: self)

--- a/OBAKit/ServiceAlerts/ServiceAlertViewController.swift
+++ b/OBAKit/ServiceAlerts/ServiceAlertViewController.swift
@@ -47,7 +47,9 @@ final class ServiceAlertViewController: UIViewController, WKNavigationDelegate {
         let builder = HTMLBuilder()
         builder.append(.h1, value: serviceAlert.summary.value)
         builder.append(.p, value: application.formatters.shortDateTimeFormatter.string(from: serviceAlert.createdAt))
-        builder.append(.p, value: serviceAlert.situationDescription.value)
+        if let description = serviceAlert.situationDescription {
+            builder.append(.p, value: description.value)
+        }
 
         if let urlString = serviceAlert.urlString?.value {
             let fmt = OBALoc("service_alert_controller.learn_more_fmt", value: "Learn more: %@", comment: "Directs the user to tap on the link that comes at the end of the string. Learn more: <HYPERLINK IS INSERTED HERE>")

--- a/OBAKitCore/Models/REST/References/ServiceAlert.swift
+++ b/OBAKitCore/Models/REST/References/ServiceAlert.swift
@@ -26,7 +26,7 @@ public class ServiceAlert: NSObject, Decodable, HasReferences {
 
     public let consequences: [Consequence]
     public let createdAt: Date
-    public let situationDescription: TranslatedString
+    public let situationDescription: TranslatedString?
     public let id: String
     public let publicationWindows: [TimeWindow]
     public let reason: String
@@ -55,7 +55,7 @@ public class ServiceAlert: NSObject, Decodable, HasReferences {
         affectedEntities = try container.decode([AffectedEntity].self, forKey: .affectedEntities)
         consequences = try container.decode([Consequence].self, forKey: .consequences)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
-        situationDescription = try container.decode(TranslatedString.self, forKey: .situationDescription)
+        situationDescription = try container.decodeIfPresent(TranslatedString.self, forKey: .situationDescription)
         id = try container.decode(String.self, forKey: .id)
         publicationWindows = try container.decode([TimeWindow].self, forKey: .publicationWindows)
         reason = try container.decode(String.self, forKey: .reason)

--- a/OBAKitTests/Modeling/Model Unit Tests/ReferencesTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ReferencesTests.swift
@@ -86,8 +86,8 @@ class ReferencesTests: OBATestCase {
         expect(situation.createdAt) == Date.fromComponents(year: 2018, month: 10, day: 13, hour: 02, minute: 26, second: 33)
 
         let desc = situation.situationDescription
-        expect(desc.lang) == "en"
-        expect(desc.value) == "Due to construction, the Washington St. off ramp from Pacific Highway will be closed Wednesday, October 17, from 6:30am - 6:30pm. Eastbound route 10 will detour, but will not miss any stops."
+        expect(desc?.lang) == "en"
+        expect(desc?.value) == "Due to construction, the Washington St. off ramp from Pacific Highway will be closed Wednesday, October 17, from 6:30am - 6:30pm. Eastbound route 10 will detour, but will not miss any stops."
 
         expect(situation.id) == "MTS_RTA:11638227"
         expect(situation.publicationWindows) == []


### PR DESCRIPTION
In some cases, the agency-provided service alert (Situation) won't have a description property, causing the stop to not load at all. This is fixed by making the service alert description optional.

## Error
```
2020-07-09 10:21:36.225476-0700 App[13081:249756] Enqueuing URL: https://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_64835.json?minutesAfter=35&minutesBefore=5&version=2&app_ver=20.2.0&app_uid=34C7C1A2-092C-4B56-BC64-1220806B19D8&key=org.onebusaway.iphone

Exception caught: https://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_64835.json?minutesAfter=35&minutesBefore=5&version=2&app_ver=20.2.0&app_uid=34C7C1A2-092C-4B56-BC64-1220806B19D8&key=org.onebusaway.iphone

valueNotFound(Swift.KeyedDecodingContainer<OBAKitCore.ServiceAlert.TranslatedString.CodingKeys>, Swift.DecodingError.Context(codingPath: [
	DataCodingKeys(stringValue: "references", intValue: nil), 
	CodingKeys(stringValue: "situations", intValue: nil), 
	_JSONKey(stringValue: "Index 0", intValue: 0), 
	CodingKeys(stringValue: "description", intValue: nil)], 
	debugDescription: "Cannot get keyed decoding container -- found null value instead.", underlyingError: nil))

2020-07-09 10:21:36.294209-0700 App[13081:250183] Error: The data couldn’t be read because it is missing.
```