### PR TITLE
TripVC UX Improvements

### DIFF
--- a/OBAKit/Bookmarks/TripBookmarkCell.swift
+++ b/OBAKit/Bookmarks/TripBookmarkCell.swift
@@ -153,8 +153,6 @@ final class TripBookmarkTableCell: SwipeCollectionViewCell, SelfSizing, Separate
     // MARK: - Data
 
     func configureView(with data: BookmarkArrivalData, formatters: Formatters) {
-        let isAccessibility = self.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-
         routeHeadsignLabel.text = data.bookmark.name
 
         guard let arrivalDepartures = data.arrivalDepartures else { return }

--- a/OBAKit/Controls/BarButtonActivityIndicator.swift
+++ b/OBAKit/Controls/BarButtonActivityIndicator.swift
@@ -1,0 +1,23 @@
+//
+//  BarButtonActivityIndicator.swift
+//  OBAKit
+//
+//  Created by Alan Chu on 7/2/20.
+//
+
+import UIKit
+
+extension UIActivityIndicatorView {
+    static func asNavigationItem() -> UIBarButtonItem {
+        let style: UIActivityIndicatorView.Style
+        if #available(iOS 13.0, *) {
+            style = .medium
+        } else {
+            style = .gray
+        }
+        let indicator = UIActivityIndicatorView(style: style)
+        indicator.startAnimating()
+
+        return UIBarButtonItem(customView: indicator)
+    }
+}

--- a/OBAKit/Controls/FloatingPanel/Layouts.swift
+++ b/OBAKit/Controls/FloatingPanel/Layouts.swift
@@ -59,3 +59,27 @@ final class MapPanelLandscapeLayout: FloatingPanelLayout {
         return 0.0
     }
 }
+
+/// A layout object used with `FloatingPanel` that restricts the panel to a single `FloatingPanelPosition`.
+final class SinglePositionMapPanelLayout: NSObject, FloatingPanelLayout {
+    let positionInset: CGFloat?
+
+    init(position: FloatingPanelPosition, positionInset: CGFloat) {
+        self.initialPosition = position
+        self.positionInset = positionInset
+    }
+
+    func insetFor(position: FloatingPanelPosition) -> CGFloat? {
+        return self.positionInset
+    }
+
+    var initialPosition: FloatingPanelPosition
+
+    var supportedPositions: Set<FloatingPanelPosition> {
+        [self.initialPosition]
+    }
+
+    var positionReference: FloatingPanelLayoutReference {
+        .fromSafeArea
+    }
+}

--- a/OBAKit/Controls/ListKit/MessageSectionController.swift
+++ b/OBAKit/Controls/ListKit/MessageSectionController.swift
@@ -135,8 +135,6 @@ final class MessageCell: BaseSelfSizingTableCell {
         subjectLabel.text = data.subject
         summaryLabel.text = data.summary
 
-        let isAccessibility = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-
         topStack.axis = isAccessibility ? .vertical : .horizontal
         authorLabel.numberOfLines = isAccessibility ? 3 : 1
 

--- a/OBAKit/Controls/Tables/TableRowView.swift
+++ b/OBAKit/Controls/Tables/TableRowView.swift
@@ -203,7 +203,6 @@ class TableRowView: UIView {
 
     override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        let isAccessibility = self.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
 
         if !(self is SubtitleTableRowView) {
             self.labelStack.axis = isAccessibility ? .vertical : .horizontal

--- a/OBAKit/Extensions/UIKitExtensions.swift
+++ b/OBAKit/Extensions/UIKitExtensions.swift
@@ -18,3 +18,10 @@ public extension UIButton {
         return button
     }
 }
+
+// MARK: - UITraitEnvironment Accessibility
+extension UITraitEnvironment {
+    var isAccessibility: Bool {
+        return traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+    }
+}

--- a/OBAKit/Stops/StopArrivalView.swift
+++ b/OBAKit/Stops/StopArrivalView.swift
@@ -105,6 +105,11 @@ class StopArrivalView: UIView {
          accessibilityRelativeTimeBadge]
     }
 
+    /// Views to set visible in accessibility when in minimal view.
+    var accessibilityMinimalInfoStack: [UIView] {
+        [accessibilityRelativeTimeBadge]
+    }
+
     /// Views containing info elements. To simplify logic, we will include all info views into the stack view.
     private lazy var infoStack = UIStackView.verticalStack(arrangedSubviews: [
         routeHeadsignLabel,

--- a/OBAKit/Stops/StopArrivalView.swift
+++ b/OBAKit/Stops/StopArrivalView.swift
@@ -228,7 +228,6 @@ class StopArrivalView: UIView {
 
     func configureView(for traitCollection: UITraitCollection) {
         guard let arrivalDeparture = arrivalDeparture else { return }
-        let accessibilityMode = self.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
 
         if deemphasizePastEvents {
             // 'Gray out' the view if it occurred in the past.
@@ -258,10 +257,10 @@ class StopArrivalView: UIView {
         accessibilityTraits = [.button, .updatesFrequently]
         isAccessibilityElement = true
 
-        normalInfoStack.forEach { $0.isHidden = accessibilityMode }
-        accessibilityInfoStack.forEach { $0.isHidden = !accessibilityMode }
+        normalInfoStack.forEach { $0.isHidden = isAccessibility }
+        accessibilityInfoStack.forEach { $0.isHidden = !isAccessibility }
 
-        infoStack.spacing = accessibilityMode ? ThemeMetrics.padding : 0
+        infoStack.spacing = isAccessibility ? ThemeMetrics.padding : 0
     }
 
     @objc func contentSizeDidChange(_ notification: Notification) {

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -296,6 +296,7 @@ public class StopViewController: UIViewController,
         guard let apiService = application.restAPIService else { return }
 
         title = Strings.updating
+        navigationItem.rightBarButtonItem = UIActivityIndicatorView.asNavigationItem()
 
         let op = apiService.getArrivalsAndDeparturesForStop(id: stopID, minutesBefore: minutesBefore, minutesAfter: minutesAfter)
         op.complete { [weak self] result in
@@ -318,6 +319,8 @@ public class StopViewController: UIViewController,
                     self.extendLoadMoreWindow()
                 }
             }
+
+            self.navigationItem.rightBarButtonItem = nil
         }
 
         self.operation = op

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import IGListKit
 import OBAKitCore
+import FloatingPanel
 
 /// Displays a list of stops for the trip corresponding to an `ArrivalDeparture` object.
 class TripFloatingPanelController: UIViewController,
@@ -112,6 +113,23 @@ class TripFloatingPanelController: UIViewController,
 
         if let listItem = listItem {
             collectionController.listAdapter.scroll(to: listItem, supplementaryKinds: nil, scrollDirection: .vertical, scrollPosition: .top, animated: true)
+        }
+    }
+
+    public func configureView(for drawerPosition: FloatingPanelPosition) {
+        let isAccessibility = self.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        switch drawerPosition {
+        case .hidden: break
+        case .tip:
+            self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = true }
+            self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = true }
+        case .half:
+            self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
+            self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = true }
+            self.stopArrivalView.accessibilityMinimalInfoStack.forEach { $0.isHidden = !isAccessibility }
+        case .full:
+            self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
+            self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = !isAccessibility }
         }
     }
 

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -36,6 +36,11 @@ class TripFloatingPanelController: UIViewController,
     }
 
     weak var parentTripViewController: TripViewController?
+    weak var tripDetailsOperation: NetworkOperation? {
+        didSet {
+            self.progressView.observedProgress = tripDetailsOperation!.progress
+        }
+    }
 
     private let operation: DecodableOperation<RESTAPIResponse<TripDetails>>?
 
@@ -172,6 +177,8 @@ class TripFloatingPanelController: UIViewController,
         return view
     }()
 
+    public lazy var progressView = UIProgressView.autolayoutNew()
+
     private lazy var separatorView: UIView = {
         let view = UIView.autolayoutNew()
         view.backgroundColor = ThemeColors.shared.separator
@@ -181,7 +188,7 @@ class TripFloatingPanelController: UIViewController,
         return view
     }()
 
-    private lazy var outerStack = UIStackView.verticalStack(arrangedSubviews: [topPaddingView, stopArrivalWrapper, separatorView, collectionController.view])
+    private lazy var outerStack = UIStackView.verticalStack(arrangedSubviews: [topPaddingView, stopArrivalWrapper, progressView, separatorView, collectionController.view])
 
     // MARK: - ViewRouterDelegate methods
 

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -117,7 +117,6 @@ class TripFloatingPanelController: UIViewController,
     }
 
     public func configureView(for drawerPosition: FloatingPanelPosition) {
-        let isAccessibility = self.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         switch drawerPosition {
         case .hidden: break
         case .tip:

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -121,13 +121,16 @@ class TripFloatingPanelController: UIViewController,
         switch drawerPosition {
         case .hidden: break
         case .tip:
-            self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = true }
+            self.separatorView.isHidden = true
+            self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
             self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = true }
         case .half:
+            self.separatorView.isHidden = false
             self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
             self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = true }
             self.stopArrivalView.accessibilityMinimalInfoStack.forEach { $0.isHidden = !isAccessibility }
         case .full:
+            self.separatorView.isHidden = false
             self.stopArrivalView.normalInfoStack.forEach { $0.isHidden = isAccessibility }
             self.stopArrivalView.accessibilityInfoStack.forEach { $0.isHidden = !isAccessibility }
         }

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -201,7 +201,7 @@ final class TripStopCell: BaseSelfSizingTableCell {
         let heightConstraint = stackWrapper.heightAnchor.constraint(greaterThanOrEqualToConstant: tripStopCellMinimumHeight)
         heightConstraint.priority = .defaultHigh
         NSLayoutConstraint.activate([
-            stackWrapper.leadingAnchor.constraint(equalTo: tripSegmentView.trailingAnchor, constant: ThemeMetrics.compactPadding),
+            stackWrapper.leadingAnchor.constraint(equalTo: tripSegmentView.trailingAnchor, constant: ThemeMetrics.padding),
             stackWrapper.topAnchor.constraint(equalTo: contentView.topAnchor),
             stackWrapper.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             heightConstraint

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -230,7 +230,6 @@ final class TripStopCell: BaseSelfSizingTableCell {
     }
 
     func layoutAccessibility() {
-        let isAccessibility = self.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
         self.textLabelsStack.axis = isAccessibility ? .vertical : .horizontal
         self.textLabelSpacerView.isHidden = isAccessibility
     }

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -14,7 +14,6 @@ fileprivate let tripStopCellMinimumHeight: CGFloat = 48.0
 // MARK: - View Model
 
 final class TripStopListItem: NSObject, ListDiffable {
-
     /// Is this where the vehicle on the trip is currently located?
     let isCurrentVehicleLocation: Bool
 
@@ -64,7 +63,7 @@ final class TripStopListItem: NSObject, ListDiffable {
     // MARK: - ListDiffable
 
     func diffIdentifier() -> NSObjectProtocol {
-        return self
+        return stop.id as NSString
     }
 
     func isEqual(toDiffableObject object: ListDiffable?) -> Bool {

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -255,7 +255,11 @@ class TripViewController: UIViewController,
                     self.mapView.addAnnotation(tripStatus)
                 }
 
-                self.mapView.showAnnotations(self.mapView.annotations, animated: true)
+                // In cases where TripStatus.coordinates is (0,0), we don't want to show it.
+                var annotationsToShow = self.mapView.annotations
+                annotationsToShow.removeAll(where: { $0.coordinate.longitude == 0 && $0.coordinate.latitude == 0 })
+
+                self.mapView.showAnnotations(annotationsToShow, animated: true)
 
                 if let arrivalDeparture = self.tripConvertible.arrivalDeparture {
                     let userDestinationStopTime = response.entry.stopTimes.filter { $0.stopID == arrivalDeparture.stopID }.first

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -220,7 +220,6 @@ class TripViewController: UIViewController,
     // MARK: - Trip Details Data
 
     private var tripDetailsOperation: DecodableOperation<RESTAPIResponse<TripDetails>>?
-
     private var currentTripStatus: TripStatus?
 
     private func loadTripDetails() {
@@ -267,8 +266,12 @@ class TripViewController: UIViewController,
             }
 
             self.navigationItem.rightBarButtonItem = self.reloadButton
+            self.tripDetailsController.progressView.isHidden = true
         }
         tripDetailsOperation = op
+
+        self.tripDetailsController.progressView.isHidden = false
+        self.tripDetailsController.progressView.observedProgress = op.progress
     }
 
     // MARK: - Map Data

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -46,7 +46,12 @@ class TripViewController: UIViewController,
 
     // MARK: - UIViewController
 
-    lazy var reloadButton = UIBarButtonItem(image: Icons.refresh, style: .plain, target: self, action: #selector(refresh))
+    lazy var reloadButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(image: Icons.refresh, style: .plain, target: self, action: #selector(refresh))
+        button.title = Strings.refresh
+        return button
+    }()
+
     let activityIndicatorButton = UIActivityIndicatorView.asNavigationItem()
 
     override func viewDidLoad() {
@@ -57,7 +62,6 @@ class TripViewController: UIViewController,
         mapView.showsScale = application.mapRegionManager.mapViewShowsScale
         application.mapRegionManager.registerAnnotationViews(mapView: mapView)
 
-        navigationItem.titleView = titleView
         updateTitleView()
 
         view.addSubview(mapView)
@@ -80,6 +84,11 @@ class TripViewController: UIViewController,
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         enableIdleTimer()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateTitleView()
     }
 
     // MARK: - NSUserActivity
@@ -123,7 +132,10 @@ class TripViewController: UIViewController,
     private let titleView = StackedMarqueeTitleView(width: 178.0)
 
     private func updateTitleView() {
+        navigationItem.titleView = isAccessibility ? nil : titleView
+
         guard let tripStatus = tripConvertible.tripStatus else {
+            title = nil
             titleView.topLabel.text = ""
             titleView.bottomLabel.text = ""
             return
@@ -131,6 +143,7 @@ class TripViewController: UIViewController,
 
         if let vehicleID = tripStatus.vehicleID {
             titleView.topLabel.text = vehicleID
+            title = vehicleID
         }
 
         if let lastUpdate = tripStatus.lastUpdate {

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -190,6 +190,8 @@ class TripViewController: UIViewController,
             let drawerHeight = vc.layout.insetFor(position: vc.position) ?? 0
             mapView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: drawerHeight, trailing: 0)
         }
+
+        self.tripDetailsController.configureView(for: vc.position)
     }
 
     // MARK: - Trip Details Data

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -414,12 +414,15 @@ class TripViewController: UIViewController,
             }
             self.mapView.deselectAnnotation(oldValue, animated: animated)
 
-            guard
-                oldValue != self.selectedStopTime,
-                let selectedStopTime = self.selectedStopTime
-            else { return }
+            guard oldValue != self.selectedStopTime,
+                let selectedStopTime = self.selectedStopTime else { return }
 
-            self.mapView.selectAnnotation(selectedStopTime, animated: animated)
+            // Fixes #220: Find matching trip stop using stop ID instead of using pointers.
+            if let annotation = self.mapView.annotations
+                .filter(type: TripStopTime.self)
+                .filter({ $0.stopID == selectedStopTime.stopID }).first {
+                self.mapView.selectAnnotation(annotation, animated: true)
+            }
         }
     }
     private var isFirstStopTimeLoad = true

--- a/OBAKitCore/Network/Operations/NetworkOperation.swift
+++ b/OBAKitCore/Network/Operations/NetworkOperation.swift
@@ -44,6 +44,9 @@ public class NetworkOperation: AsyncOperation, Requestable {
     public let request: URLRequest
     public private(set) var response: HTTPURLResponse?
     public private(set) var data: Data?
+
+    public let progress: Progress = Progress(totalUnitCount: 1)
+
     private var dataTask: URLSessionDataTask?
     private let dataLoader: URLDataLoader
 
@@ -74,7 +77,7 @@ public class NetworkOperation: AsyncOperation, Requestable {
 
             self.finish()
         }
-
+        progress.addChild(task.progress, withPendingUnitCount: 1)
         task.resume()
         self.dataTask = task
     }


### PR DESCRIPTION
- [UI] Dynamic Type
   - StopArrivalView will adjust its contents depending on the drawer's position to make better use of available space during large text sizes.
- [UX] There is a progress view indicating trip detail loading progress
   - The drawer will be unavailable until trip details have been loaded.
   - You won't notice this on a fast LTE connection, it is intended for poor/slow connections, such as in a tunnel or 2G speeds.
- [UX] Fixes #220
- [UX] Fixes map zooming out to the whole world on reload when TripStatus.coordinates is 0,0
- [UI] Show activity indicator during network operations in StopVC and TripVC (in place of reload button)
- [DEV] Adds `isAccessibility` property to UITraitEnvironment (equivalent to `self.traitCollection.preferredContentSizeCategory.isAccessibilityCategory`)

No voiceover in this PR. I'm researching how to better handle the drawer in voiceover.

## Screenshot
<img src="https://user-images.githubusercontent.com/22162410/87078506-9760f800-c1d9-11ea-8538-b607d681926d.png" width=256>
