### PR TITLE
Improves support for iPad

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -48,11 +48,7 @@ targets:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        UISupportedInterfaceOrientations~ipad:
-          - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationPortraitUpsideDown
-          - UIInterfaceOrientationLandscapeLeft
-          - UIInterfaceOrientationLandscapeRight
     preBuildScripts:
       - name: Versioning
         script: "${PROJECT_DIR}/scripts/version"

--- a/OBAKit/Bookmarks/BookmarkSectionController.swift
+++ b/OBAKit/Bookmarks/BookmarkSectionController.swift
@@ -367,8 +367,8 @@ final class CollapsibleHeaderCell: SelfSizingCollectionCell {
 
         NSLayoutConstraint.activate([
             stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -ThemeMetrics.compactPadding),
-            stack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            stack.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
 
             contentView.heightAnchor.constraint(greaterThanOrEqualTo: stack.heightAnchor),
             contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 40.0)

--- a/OBAKit/Bookmarks/BookmarkSectionController.swift
+++ b/OBAKit/Bookmarks/BookmarkSectionController.swift
@@ -19,6 +19,7 @@ enum BookmarkSectionState: String, Codable {
 }
 
 typealias BookmarkListCallback = (Bookmark) -> Void
+typealias BookmarkDeleteCallback = (Bookmark, UIView?, CGRect?) -> Void
 typealias BookmarkSectionToggled = (BookmarkSectionData, BookmarkSectionState) -> Void
 
 /// A view model used with `IGListKit` to display `Bookmark` data in the `BookmarksViewController`.
@@ -26,12 +27,12 @@ final class BookmarkArrivalData: NSObject, ListDiffable {
     public let bookmark: Bookmark
     public let arrivalDepartures: [ArrivalDeparture]?
     let selected: BookmarkListCallback
-    let deleted: BookmarkListCallback
+    let deleted: BookmarkDeleteCallback
     let edited: BookmarkListCallback
 
     var previewDestination: ControllerPreviewProvider?
 
-    public init(bookmark: Bookmark, arrivalDepartures: [ArrivalDeparture]?, selected: @escaping BookmarkListCallback, deleted: @escaping BookmarkListCallback, edited: @escaping BookmarkListCallback) {
+    public init(bookmark: Bookmark, arrivalDepartures: [ArrivalDeparture]?, selected: @escaping BookmarkListCallback, deleted: @escaping BookmarkDeleteCallback, edited: @escaping BookmarkListCallback) {
         self.bookmark = bookmark
         self.arrivalDepartures = arrivalDepartures
         self.selected = selected
@@ -258,7 +259,11 @@ final class BookmarkSectionController: OBAListSectionController<BookmarkSectionD
         }
 
         let delete = SwipeAction(style: .destructive, title: Strings.delete) { _, _ in
-            bookmark.deleted(bookmark.bookmark)
+            let cell = collectionView.cellForItem(at: indexPath)
+            var frame = collectionView.layoutAttributesForItem(at: indexPath)?.bounds ?? .zero
+            frame.origin.x = frame.width - 60.0
+
+            bookmark.deleted(bookmark.bookmark, cell, frame)
         }
 
         return [delete, edit]

--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -126,7 +126,7 @@ public class BookmarksViewController: UIViewController,
                 arrDeps = dataLoader.dataForKey(key)
             }
 
-            let viewModel = BookmarkArrivalData(bookmark: bm, arrivalDepartures: arrDeps, selected: didSelectBookmark(_:), deleted: didDeleteBookmark(_:), edited: didEditBookmark(_:))
+            let viewModel = BookmarkArrivalData(bookmark: bm, arrivalDepartures: arrDeps, selected: didSelectBookmark(_:), deleted: didDeleteBookmark(_:sourceView:sourceFrame:), edited: didEditBookmark(_:))
             viewModel.previewDestination = { StopViewController(application: self.application, stop: bm.stop) }
 
             return viewModel
@@ -166,7 +166,7 @@ public class BookmarksViewController: UIViewController,
         application.viewRouter.navigateTo(stop: bookmark.stop, from: self, bookmark: bookmark)
     }
 
-    private func didDeleteBookmark(_ bookmark: Bookmark) {
+    private func didDeleteBookmark(_ bookmark: Bookmark, sourceView: UIView?, sourceFrame: CGRect?) {
         let title = OBALoc("bookmarks_controller.delete_bookmark.actionsheet.title", value: "Delete Bookmark", comment: "The title to display to confirm the user's action to delete a bookmark.")
         let message = OBALoc("bookmarks_controller.delete_bookmark.actionsheet.message", value: "Are you sure you want to delete %@?", comment: "The message to display to confirm the user's action to delete a bookmark, includes a placeholder to display the bookmark's name.")
         let formattedMessage = String(format: message, bookmark.name)
@@ -185,9 +185,16 @@ public class BookmarksViewController: UIViewController,
             self?.application.userDataStore.delete(bookmark: bookmark)
             self?.collectionController.reload(animated: true)
         }
+
         alert.addAction(title: Strings.cancel, style: .cancel, handler: nil)
 
-        self.present(alert, animated: true)
+        application.viewRouter.present(
+            alert,
+            from: self,
+            isPopover: traitCollection.userInterfaceIdiom == .pad,
+            popoverSourceView: sourceView,
+            popoverSourceFrame: sourceFrame
+        )
     }
 
     private func didEditBookmark(_ bookmark: Bookmark) {

--- a/OBAKit/Controls/FloatingPanel/Layouts.swift
+++ b/OBAKit/Controls/FloatingPanel/Layouts.swift
@@ -37,12 +37,13 @@ final class MapPanelLandscapeLayout: FloatingPanelLayout {
     var initialPosition: FloatingPanelPosition
 
     public var supportedPositions: Set<FloatingPanelPosition> {
-        return [.full, .tip]
+        return [.full, .half, .tip]
     }
 
     public func insetFor(position: FloatingPanelPosition) -> CGFloat? {
         switch position {
         case .full: return 16.0
+        case .half: return 250.0
         case .tip: return 69.0
         default: return nil
         }

--- a/OBAKit/Controls/ListKit/TableCells.swift
+++ b/OBAKit/Controls/ListKit/TableCells.swift
@@ -24,8 +24,8 @@ class TableRowCell: SwipeCollectionViewCell, SelfSizing, Separated {
 
             contentView.addSubview(tableRowView)
             NSLayoutConstraint.activate([
-                tableRowView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
-                tableRowView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+                tableRowView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
+                tableRowView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
                 tableRowView.topAnchor.constraint(equalTo: contentView.topAnchor),
                 tableRowView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
                 tableRowView.heightAnchor.constraint(greaterThanOrEqualToConstant: 40.0)

--- a/OBAKit/Controls/ListKit/TableHeaderSection.swift
+++ b/OBAKit/Controls/ListKit/TableHeaderSection.swift
@@ -79,8 +79,8 @@ final class TableHeaderCell: SelfSizingCollectionCell, Separated {
         addSubview(textLabel)
 
         NSLayoutConstraint.activate([
-            textLabel.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            textLabel.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            textLabel.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
+            textLabel.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
             textLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: ThemeMetrics.compactPadding),
             bottomLabelAnchor
         ])

--- a/OBAKit/Controls/ListKit/TableSectionHeaderView.swift
+++ b/OBAKit/Controls/ListKit/TableSectionHeaderView.swift
@@ -26,8 +26,8 @@ class TableSectionHeaderView: UICollectionReusableView, Separated {
         addSubview(textLabel)
 
         NSLayoutConstraint.activate([
-            textLabel.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            textLabel.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            textLabel.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
+            textLabel.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
             bottomLabelAnchor
         ])
 

--- a/OBAKit/Controls/Tables/TableHeaderView.swift
+++ b/OBAKit/Controls/Tables/TableHeaderView.swift
@@ -38,9 +38,9 @@ class TableHeaderView: UIView {
 
         addSubview(textLabel)
         NSLayoutConstraint.activate([
-            textLabel.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            textLabel.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
             textLabel.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
-            textLabel.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            textLabel.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
             textLabel.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
         ])
     }

--- a/OBAKit/Mapping/MapStatusView.swift
+++ b/OBAKit/Mapping/MapStatusView.swift
@@ -105,8 +105,8 @@ class MapStatusView: UIView {
 
         NSLayoutConstraint.activate([
             stackView.centerXAnchor.constraint(equalTo: visualView.layoutMarginsGuide.centerXAnchor),
-            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: visualView.layoutMarginsGuide.leadingAnchor),
-            stackView.trailingAnchor.constraint(lessThanOrEqualTo: visualView.layoutMarginsGuide.trailingAnchor),
+            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: visualView.readableContentGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: visualView.readableContentGuide.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: visualView.layoutMarginsGuide.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: visualView.layoutMarginsGuide.bottomAnchor)
         ])

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -338,9 +338,9 @@ public class MapViewController: UIViewController,
     }()
 
     public func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
-        switch newCollection.verticalSizeClass {
-        case .compact:
-            return MapPanelLandscapeLayout(initialPosition: .tip)
+        switch newCollection.horizontalSizeClass {
+        case .regular:
+            return MapPanelLandscapeLayout(initialPosition: .half)
         default:
             return MapPanelLayout(initialPosition: .tip)
         }

--- a/OBAKit/Settings/MoreViewController.swift
+++ b/OBAKit/Settings/MoreViewController.swift
@@ -38,7 +38,7 @@ public class MoreViewController: UIViewController,
         tabBarItem.image = Icons.moreTabIcon
 
         let contactUs = OBALoc("more_controller.contact_us", value: "Contact Us", comment: "A button to contact transit agency/developers.")
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: contactUs, style: .plain, target: self, action: #selector(showContactUsDialog))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: contactUs, style: .plain, target: self, action: #selector(showContactUsDialog(_:)))
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.settings, style: .plain, target: self, action: #selector(showSettings))
 
         application.regionsService.addDelegate(self)
@@ -184,7 +184,7 @@ public class MoreViewController: UIViewController,
         }
     }
 
-    @objc func showContactUsDialog() {
+    @objc func showContactUsDialog(_ sender: UIBarButtonItem) {
         let sheetTitle = OBALoc("more_controller.contact_us_alert_title", value: "Contact Us", comment: "Contact Us alert title.")
         let sheet = UIAlertController(title: sheetTitle, message: nil, preferredStyle: .actionSheet)
 
@@ -204,7 +204,12 @@ public class MoreViewController: UIViewController,
 
         sheet.addAction(UIAlertAction.cancelAction)
 
-        present(sheet, animated: true, completion: nil)
+        application.viewRouter.present(
+            sheet,
+            from: self,
+            isPopover: traitCollection.userInterfaceIdiom == .pad,
+            popoverBarButtonItem: sender
+        )
     }
 
     // MARK: - About Section

--- a/OBAKit/Stops/StopArrivalListItem.swift
+++ b/OBAKit/Stops/StopArrivalListItem.swift
@@ -20,7 +20,7 @@ final class ArrivalDepartureSectionData: NSObject, ListDiffable {
     let selected: VoidBlock
 
     var onCreateAlarm: VoidBlock?
-    var onShowOptions: VoidBlock?
+    var onShowOptions: ((UIView?, CGRect?) -> Void)?
     var onAddBookmark: VoidBlock?
     var onShareTrip: VoidBlock?
 
@@ -99,7 +99,11 @@ final class StopArrivalSectionController: OBAListSectionController<ArrivalDepart
         }
 
         let moreActions = SwipeAction(style: .default, title: Strings.more) { (_, _) in
-            sectionData.onShowOptions?()
+            let cell = collectionView.cellForItem(at: indexPath)
+            var frame = collectionView.layoutAttributesForItem(at: indexPath)?.bounds ?? .zero
+            frame.origin.x = frame.width - 110.0
+
+            sectionData.onShowOptions?(cell, frame)
         }
         moreActions.font = UIFont.preferredFont(forTextStyle: .caption1)
         moreActions.backgroundColor = ThemeColors.shared.green

--- a/OBAKit/Stops/StopHeaderController.swift
+++ b/OBAKit/Stops/StopHeaderController.swift
@@ -117,8 +117,8 @@ class StopHeaderView: UIView {
         addSubview(stack)
 
         NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            stack.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
             stack.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor, constant: ThemeMetrics.padding),
             stack.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
         ])

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -505,9 +505,9 @@ public class StopViewController: UIViewController,
             self.shareTripStatus(arrivalDeparture: arrivalDeparture)
         }
 
-        data.onShowOptions = { [weak self] in
+        data.onShowOptions = { [weak self] view, frame in
             guard let self = self else { return }
-            self.showMoreOptions(arrivalDeparture: arrivalDeparture)
+            self.showMoreOptions(arrivalDeparture: arrivalDeparture, sourceView: view, sourceFrame: frame)
         }
 
         return data
@@ -686,7 +686,7 @@ public class StopViewController: UIViewController,
 
     // MARK: - Stop Arrival Actions
 
-    public func showMoreOptions(arrivalDeparture: ArrivalDeparture) {
+    public func showMoreOptions(arrivalDeparture: ArrivalDeparture, sourceView: UIView?, sourceFrame: CGRect?) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         actionSheet.addAction(title: Strings.addBookmark) { [weak self] _ in
@@ -703,7 +703,13 @@ public class StopViewController: UIViewController,
 
         actionSheet.addAction(UIAlertAction.cancelAction)
 
-        application.viewRouter.present(actionSheet, from: self)
+        application.viewRouter.present(
+            actionSheet,
+            from: self,
+            isPopover: traitCollection.userInterfaceIdiom == .pad,
+            popoverSourceView: sourceView,
+            popoverSourceFrame: sourceFrame
+        )
     }
 
     // MARK: - Alarms

--- a/OBAKit/Stops/WalkTimeView.swift
+++ b/OBAKit/Stops/WalkTimeView.swift
@@ -63,13 +63,13 @@ class WalkTimeView: UIView {
 
         NSLayoutConstraint.activate([
             walkerImageView.topAnchor.constraint(equalTo: topAnchor, constant: ThemeMetrics.ultraCompactPadding),
-            walkerImageView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor, constant: -walkerImageInset - 5.0),
+            walkerImageView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor, constant: -walkerImageInset - 5.0),
             walkerImageView.heightAnchor.constraint(equalToConstant: 16.0),
             walkerImageView.widthAnchor.constraint(equalToConstant: 16.0),
 
             label.topAnchor.constraint(equalTo: topAnchor),
             label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -triangleHeight),
-            label.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            label.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
             label.trailingAnchor.constraint(equalTo: walkerImageView.leadingAnchor, constant: -ThemeMetrics.padding)
         ])
     }

--- a/OBAKit/Trip/TripFloatingPanelController.swift
+++ b/OBAKit/Trip/TripFloatingPanelController.swift
@@ -163,8 +163,8 @@ class TripFloatingPanelController: UIViewController,
         let wrapper = stopArrivalView.embedInWrapperView(setConstraints: false)
         NSLayoutConstraint.activate([
             stopArrivalView.topAnchor.constraint(equalTo: wrapper.topAnchor, constant: ThemeMetrics.padding),
-            stopArrivalView.leadingAnchor.constraint(equalTo: wrapper.layoutMarginsGuide.leadingAnchor),
-            stopArrivalView.trailingAnchor.constraint(equalTo: wrapper.layoutMarginsGuide.trailingAnchor),
+            stopArrivalView.leadingAnchor.constraint(equalTo: wrapper.readableContentGuide.leadingAnchor),
+            stopArrivalView.trailingAnchor.constraint(equalTo: wrapper.readableContentGuide.trailingAnchor),
             stopArrivalView.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor, constant: -ThemeMetrics.compactPadding)
         ])
         return wrapper

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -209,7 +209,7 @@ final class TripStopCell: BaseSelfSizingTableCell {
         contentView.addSubview(accessoryImageView)
         NSLayoutConstraint.activate([
             accessoryImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            accessoryImageView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            accessoryImageView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
             accessoryImageView.widthAnchor.constraint(equalToConstant: 16),
             stackWrapper.trailingAnchor.constraint(equalTo: accessoryImageView.leadingAnchor, constant: -ThemeMetrics.padding)
         ])

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -185,9 +185,9 @@ class TripViewController: UIViewController,
 
     public func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
         let layout: FloatingPanelLayout
-        switch newCollection.verticalSizeClass {
-        case .compact:
-            layout = MapPanelLandscapeLayout(initialPosition: .full)
+        switch newCollection.horizontalSizeClass {
+        case .regular:
+            layout = MapPanelLandscapeLayout(initialPosition: .half)
         default:
             layout = MapPanelLayout(initialPosition: .half)
         }

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -29,19 +29,36 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
     }
 
     /// Modally presents the specified view controller.
-    /// - Parameter presentedController: The modally-presented controller.
-    /// - Parameter fromController: The controller that presents `presentedController`.
-    /// - Parameter isModal: When running on iOS 13 and above, this is the value that will be set for
-    ///                                    `presentedController.isModalInPresentation`, which controls whether
-    ///                                    a modal view controller can be interactively dismissed by the user. Defaults
-    ///                                    to `false`, mirroring iOS's behavior.
+    /// - Parameters:
+    ///   - presentedController: The modally-presented controller.
+    ///   - fromController: The controller that presents `presentedController`.
+    ///   - isModal: When running on iOS 13 and above, this is the value that will be set for `presentedController.isModalInPresentation`,
+    ///              which controls whether a modal view controller can be interactively dismissed by the user. Defaults to `false`, mirroring iOS's behavior.
+    ///   - isPopover: if `presentedController` should be displayed as a popover. If this is true, then the next two parameters must also be set.
+    ///   - popoverSourceView: Used to set the `sourceView` property of the popover presentation controller.
+    ///   - popoverSourceFrame: Used to set the `sourceRect` property of the popover presentation controller.
+    ///   - popoverBarButtonItem: Used to set the `sourceRect` property of the popover presentation controller.
     public func present(
         _ presentedController: UIViewController,
         from fromController: UIViewController,
-        isModal: Bool = false
+        isModal: Bool = false,
+        isPopover: Bool = false,
+        popoverSourceView: UIView? = nil,
+        popoverSourceFrame: CGRect? = nil,
+        popoverBarButtonItem: UIBarButtonItem? = nil
     ) {
         if #available(iOS 13.0, *) {
             presentedController.isModalInPresentation = isModal
+        }
+
+        if isPopover, let popover = presentedController.popoverPresentationController {
+            if let popoverSourceFrame = popoverSourceFrame {
+                popover.sourceRect = popoverSourceFrame
+            }
+
+            popover.sourceView = popoverSourceView
+            popover.barButtonItem = popoverBarButtonItem
+            presentedController.modalPresentationStyle = .popover
         }
 
         fromController.present(presentedController, animated: true, completion: nil)

--- a/OBAKitCore/Collections/EmptyDataSetView.swift
+++ b/OBAKitCore/Collections/EmptyDataSetView.swift
@@ -65,8 +65,8 @@ public class EmptyDataSetView: UIView {
         let stack = UIStackView.verticalStack(arrangedSubviews: [titleLabel, bodyLabel])
         addSubview(stack)
 
-        let leading = stack.leadingAnchor.constraint(equalTo: self.layoutMarginsGuide.leadingAnchor)
-        let trailing = stack.trailingAnchor.constraint(equalTo: self.layoutMarginsGuide.trailingAnchor)
+        let leading = stack.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor)
+        let trailing = stack.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor)
 
         // Priorities are specified to ensure that, for the period of time when this view
         // has a width==0, we don't end up with 'unsatisfiable constraints' errors.
@@ -76,10 +76,10 @@ public class EmptyDataSetView: UIView {
         let vertical: NSLayoutConstraint
 
         if alignment == .center {
-            vertical = stack.centerYAnchor.constraint(equalTo: self.layoutMarginsGuide.centerYAnchor)
+            vertical = stack.centerYAnchor.constraint(equalTo: layoutMarginsGuide.centerYAnchor)
         }
         else {
-            vertical = stack.topAnchor.constraint(equalTo: self.layoutMarginsGuide.topAnchor)
+            vertical = stack.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor)
         }
 
         NSLayoutConstraint.activate([vertical, leading, trailing])


### PR DESCRIPTION
Part of the work necessary for #28. Doesn't complete it per se, but gets things far enough along that I will close that issue and open more specific tasks.

* Improves floating panel layout.
* Enables split screen multitasking.
* replaces `layoutMarginsGuide` with `readableContentGuide` in several places to improve content readability on iPad.
* Displays `UIAlertController`s with the `actionSheet` style in popovers to prevent crashes on iPad.