### PR TITLE
Fixes #264

### DIFF
--- a/OBAKit/Controls/ListKit/MessageSectionController.swift
+++ b/OBAKit/Controls/ListKit/MessageSectionController.swift
@@ -119,7 +119,7 @@ final class MessageCell: BaseSelfSizingTableCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        self.topStack = UIStackView.horizontalStack(arrangedSubviews: [authorLabel, dateLabel])
+        self.topStack = UIStackView.horizontalStack(arrangedSubviews: [unreadDot, authorLabel, dateLabel])
         self.topStack.spacing = ThemeMetrics.compactPadding
         let topWrapper = topStack.embedInWrapperView()
 
@@ -141,19 +141,18 @@ final class MessageCell: BaseSelfSizingTableCell {
     private func configureView() {
         guard let data = data else { return }
 
-        if data.isUnread {
-            topStack.insertArrangedSubview(unreadDot, at: 0)
-            unreadDot.isHidden = false
-        }
-        else {
-            topStack.removeArrangedSubview(unreadDot)
-            unreadDot.isHidden = true
-        }
+        unreadDot.isHidden = !data.isUnread
 
         authorLabel.text = data.author
         dateLabel.text = data.date
         subjectLabel.text = data.subject
-        summaryLabel.text = data.summary
+
+        // Fixes #264. Truncate the summary text for UILabel typesetting performance.
+        if let summary = data.summary {
+            summaryLabel.text = String(summary.prefix(data.summaryNumberOfLines * 128))
+        } else {
+            summaryLabel.text = nil
+        }
 
         topStack.axis = isAccessibility ? .vertical : .horizontal
         authorLabel.numberOfLines = isAccessibility ? 3 : 1


### PR DESCRIPTION
Instruments reveals that UILabel typesetting is taking a long time.
![Screen Shot 2020-07-25 at 10 00 31 PM](https://user-images.githubusercontent.com/22162410/88471883-d45c0880-cec2-11ea-819f-bf235132c989.png)

Turns out this KCM alert had an essay as its body, which is put verbatim into the view model. Trying to fit 7000+ unicode characters, then truncating it to fit into two lines turns out to be extremely expensive.
![Screen Shot 2020-07-25 at 9 53 26 PM](https://user-images.githubusercontent.com/22162410/88471896-e63dab80-cec2-11ea-81b1-8a6a656506df.png)

Because agencies may provide whatever they want in the service alert, the solution is to truncate the string before applying it to the UILabel. The number I came up with was 128. There is about 53 characters in the first line on an iPhone X in standard content size, so I rounded it up to 64, then added another 64 for iPad. It's kinda arbitrary but it works. I'm not trying to be exact so UILabel can still add the ellipsis if it needs to be truncated further.

The 14 second operation now only takes a second<sub>ish</sub>.