### PR TITLE
CI continue on failure

### DIFF
--- a/.github/workflows/obakittests.yml
+++ b/.github/workflows/obakittests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: macos-latest
-    
+    continue-on-error: true
     steps:
     - uses: actions/checkout@v2
 

--- a/OBAKitTests/Location/LocationServiceTests.swift
+++ b/OBAKitTests/Location/LocationServiceTests.swift
@@ -18,6 +18,7 @@ class LocationServiceTests: XCTestCase {
     // MARK: - Authorization
 
     func test_authorization_defaultValueIsNotDetermined() {
+        XCFail("faksljdfhla")
         let service = LocationService(userDefaults: UserDefaults(), locationManager: LocationManagerMock())
 
         expect(service.authorizationStatus) == .notDetermined

--- a/OBAKitTests/Location/LocationServiceTests.swift
+++ b/OBAKitTests/Location/LocationServiceTests.swift
@@ -18,7 +18,7 @@ class LocationServiceTests: XCTestCase {
     // MARK: - Authorization
 
     func test_authorization_defaultValueIsNotDetermined() {
-        XCFail("faksljdfhla")
+        XCTFail("faksljdfhla")
         let service = LocationService(userDefaults: UserDefaults(), locationManager: LocationManagerMock())
 
         expect(service.authorizationStatus) == .notDetermined


### PR DESCRIPTION
Currently, CI stops when something in the pipeline has failed, causing the step of uploading xcresult being skipped thus defeating the purpose of uploading xcresult for debugging problems.

See https://github.com/OneBusAway/OBAKit/actions/runs/234545949 for example.