### PR TITLE
Change minimum supported version to iOS 13.7

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -9,11 +9,11 @@ settings:
     CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED: true
 
 options:
-  minimumXcodeGenVersion: 2.10
+  minimumXcodeGenVersion: 2.17
   generateEmptyDirectories: true
   groupSortPosition: top
-  deploymentTarget: 
-    iOS: "12.4"
+  deploymentTarget:
+    iOS: "13.6"
 
 ############
 # App

--- a/OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OBAKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,17 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "2b1809051b4a65c1d7f5233331daa24572cd7fca",
-          "version": "8.1.1"
+          "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
+          "version": "8.1.2"
+        }
+      },
+      {
+        "package": "OneSignal",
+        "repositoryURL": "https://github.com/OneSignal/OneSignal-iOS-SDK.git",
+        "state": {
+          "branch": null,
+          "revision": "e762b39aba93cfe357d24ceb5534d93bc148b363",
+          "version": "2.15.3"
         }
       },
       {

--- a/OBAKit/Bookmarks/BookmarkSectionController.swift
+++ b/OBAKit/Bookmarks/BookmarkSectionController.swift
@@ -273,7 +273,6 @@ final class BookmarkSectionController: OBAListSectionController<BookmarkSectionD
 
     // MARK: - Context Menus
 
-    @available(iOS 13.0, *)
     func contextMenuConfiguration(forItemAt indexPath: IndexPath) -> UIContextMenuConfiguration? {
         guard let sectionData = sectionData else { return nil }
         if hasTitleRow && indexPath.row == 0 { return nil }

--- a/OBAKit/Controls/BarButtonActivityIndicator.swift
+++ b/OBAKit/Controls/BarButtonActivityIndicator.swift
@@ -9,13 +9,7 @@ import UIKit
 
 extension UIActivityIndicatorView {
     static func asNavigationItem() -> UIBarButtonItem {
-        let style: UIActivityIndicatorView.Style
-        if #available(iOS 13.0, *) {
-            style = .medium
-        } else {
-            style = .gray
-        }
-        let indicator = UIActivityIndicatorView(style: style)
+        let indicator = UIActivityIndicatorView(style: .medium)
         indicator.startAnimating()
 
         return UIBarButtonItem(customView: indicator)

--- a/OBAKit/Controls/FakeToolbar.swift
+++ b/OBAKit/Controls/FakeToolbar.swift
@@ -46,9 +46,7 @@ class FakeToolbar: UIView {
             stackWrapper.topAnchor.constraint(equalTo: blurContainerView.contentView.topAnchor)
         ])
 
-        if #available(iOS 13, *) {
-            self.addInteraction(UILargeContentViewerInteraction())
-        }
+        addInteraction(UILargeContentViewerInteraction())
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -74,11 +72,8 @@ class FakeToolbar: UIView {
         button.setImage(image, for: .normal)
         button.addTarget(target, action: action, for: .touchUpInside)
         NSLayoutConstraint.activate([button.heightAnchor.constraint(greaterThanOrEqualToConstant: 40.0)])
-
-        if #available(iOS 13, *) {
-            button.showsLargeContentViewer = true
-            button.scalesLargeContentImage = true
-        }
+        button.showsLargeContentViewer = true
+        button.scalesLargeContentImage = true
         return button
     }
 }

--- a/OBAKit/Controls/ListKit/Alerts/TransitAlertCell.swift
+++ b/OBAKit/Controls/ListKit/Alerts/TransitAlertCell.swift
@@ -34,10 +34,7 @@ final class TransitAlertCell: BaseSelfSizingTableCell {
         view.setCompressionResistance(vertical: .required)
         view.setHugging(horizontal: .defaultHigh)
         view.tintColor = ThemeColors.shared.brand
-
-        if #available(iOS 13, *) {
-            view.preferredSymbolConfiguration = .init(font: .preferredFont(forTextStyle: .headline))
-        }
+        view.preferredSymbolConfiguration = .init(font: .preferredFont(forTextStyle: .headline))
 
         return view
     }()

--- a/OBAKit/Controls/ListKit/CollectionController.swift
+++ b/OBAKit/Controls/ListKit/CollectionController.swift
@@ -133,7 +133,6 @@ public class CollectionController: UIViewController, UICollectionViewDelegate {
 
     // MARK: - UICollectionViewDelegate
 
-    @available(iOS 13.0, *)
     public func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
         guard let provider = listAdapter.sectionController(forSection: indexPath.section) as? ContextMenuProvider else {
             return nil
@@ -142,7 +141,6 @@ public class CollectionController: UIViewController, UICollectionViewDelegate {
         return provider.contextMenuConfiguration(forItemAt: indexPath)
     }
 
-     @available(iOS 13.0, *)
      public func collectionView(_ collectionView: UICollectionView, willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionCommitAnimating) {
         guard
             let viewController = animator.previewViewController,

--- a/OBAKit/Controls/ListKit/EmptyDataSetSectionController.swift
+++ b/OBAKit/Controls/ListKit/EmptyDataSetSectionController.swift
@@ -40,12 +40,6 @@ final class EmptyDataSetSectionData: NSObject, ListDiffable {
             return
         }
 
-        // And the target is iOS 13+...
-        guard #available(iOS 13, *) else {
-            self.init(alignment: .center, title: nil, body: error.localizedDescription, image: image, buttonConfig: buttonConfig)
-            return
-        }
-
         // Then, add an icon if applicable.
         var icon: UIImage?
         switch error {

--- a/OBAKit/Controls/ListKit/LoadMoreSection.swift
+++ b/OBAKit/Controls/ListKit/LoadMoreSection.swift
@@ -117,11 +117,9 @@ final class LoadMoreCell: SelfSizingCollectionCell {
         contentView.addSubview(stack)
         stack.pinToSuperview(.layoutMargins)
 
-        if #available(iOS 13, *) {
-            self.largeContentTitle = LoadMoreCell.loadMoreLocalized
-            self.showsLargeContentViewer = true
-            self.addInteraction(UILargeContentViewerInteraction())
-        }
+        self.largeContentTitle = LoadMoreCell.loadMoreLocalized
+        self.showsLargeContentViewer = true
+        self.addInteraction(UILargeContentViewerInteraction())
 
         configureView()
     }

--- a/OBAKit/Controls/ListKit/OBAListSectionController.swift
+++ b/OBAKit/Controls/ListKit/OBAListSectionController.swift
@@ -23,7 +23,6 @@ protocol Previewable: NSObjectProtocol {
     func exitPreviewMode()
 }
 
-@available(iOS 13.0, *)
 protocol ContextMenuProvider {
     func contextMenuConfiguration(forItemAt indexPath: IndexPath) -> UIContextMenuConfiguration?
 }

--- a/OBAKit/Controls/ListKit/TableSectionController.swift
+++ b/OBAKit/Controls/ListKit/TableSectionController.swift
@@ -219,7 +219,6 @@ final class TableSectionController: OBAListSectionController<TableSectionData>, 
     }
 
     // MARK: - Context Menu
-    @available(iOS 13.0, *)
     func contextMenuConfiguration(forItemAt indexPath: IndexPath) -> UIContextMenuConfiguration? {
         guard let sectionData = self.sectionData else { return nil }
         let tableRow = sectionData.rows[indexPath.item]

--- a/OBAKit/Controls/ProgressHUD/SVProgressHUD.m
+++ b/OBAKit/Controls/ProgressHUD/SVProgressHUD.m
@@ -14,6 +14,9 @@
 #import "SVProgressAnimatedView.h"
 #import "SVRadialGradientLayer.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 NSString * const SVProgressHUDDidReceiveTouchEventNotification = @"SVProgressHUDDidReceiveTouchEventNotification";
 NSString * const SVProgressHUDDidTouchDownInsideNotification = @"SVProgressHUDDidTouchDownInsideNotification";
 NSString * const SVProgressHUDWillDisappearNotification = @"SVProgressHUDWillDisappearNotification";
@@ -1569,3 +1572,5 @@ static const CGFloat SVProgressHUDLabelSpacing = 8.0f;
 }
 
 @end
+
+#pragma clang diagnostic pop

--- a/OBAKit/Controls/VisualEffectsShadow/HoverBar.swift
+++ b/OBAKit/Controls/VisualEffectsShadow/HoverBar.swift
@@ -114,10 +114,8 @@ class HoverBarPassThroughView: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if #available(iOS 13.0, *) {
-            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-                transition(to: traitCollection.userInterfaceStyle)
-            }
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            transition(to: traitCollection.userInterfaceStyle)
         }
     }
 
@@ -133,16 +131,10 @@ class HoverBarPassThroughView: UIView {
     }
 
     fileprivate func lazyVisualEffectView() -> UIVisualEffectView {
-
         // The "system thin" material automatically adapts to changes to the `UIUserInterfaceStyle`.
         // The only we need to do here is show/ hide the shadow.
-        let blurEffect: UIBlurEffect
+        let blurEffect = UIBlurEffect(style: .systemThinMaterial)
 
-        if #available(iOS 13.0, *) {
-            blurEffect = UIBlurEffect(style: .systemThinMaterial)
-        } else {
-            blurEffect = UIBlurEffect(style: .regular)
-        }
         let view = UIVisualEffectView(effect: blurEffect)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.layer.cornerRadius = Properties.cornerRadius

--- a/OBAKit/Mapping/MapFloatingPanelController.swift
+++ b/OBAKit/Mapping/MapFloatingPanelController.swift
@@ -170,11 +170,7 @@ class MapFloatingPanelController: VisualEffectViewController,
 
     private lazy var searchModeEmptyView: EmptyDataSetView = {
         let emptyView = EmptyDataSetView(alignment: .top)
-
-        if #available(iOS 13, *) {
-            emptyView.imageView.image = UIImage(systemName: "magnifyingglass")
-        }
-
+        emptyView.imageView.image = UIImage(systemName: "magnifyingglass")
         emptyView.titleLabel.text = OBALoc("search_controller.empty_set.title", value: "Search", comment: "Title for the empty set indicator on the Search controller.")
         emptyView.bodyLabel.text = OBALoc("search_controller.empty_set.body", value: "Type in an address, route name, stop number, or vehicle here to search.", comment: "Body for the empty set indicator on the Search controller.")
 

--- a/OBAKit/Mapping/MapSnapshotter.swift
+++ b/OBAKit/Mapping/MapSnapshotter.swift
@@ -41,10 +41,7 @@ class MapSnapshotter: NSObject {
         options.region = MapHelpers.coordinateRegionWith(center: stop.coordinate, zoomLevel: zoomLevel, size: size)
         options.scale = scale
         options.mapType = mapType
-
-        if #available(iOS 13.0, *) {
-            options.traitCollection = traitCollection
-        }
+        options.traitCollection = traitCollection
 
         return options
     }

--- a/OBAKit/Mapping/MapStatusView.swift
+++ b/OBAKit/Mapping/MapStatusView.swift
@@ -135,17 +135,13 @@ class MapStatusView: UIView {
         switch state {
         case .locationServicesUnavailable, .locationServicesOff, .notDetermined:
             setHidden = false
-            if #available(iOS 13.0, *) {
-                setImage = UIImage(systemName: "location.slash")!
-                setLargeImage = UIImage(systemName: "location.slash.fill")!
-            }
+            setImage = UIImage(systemName: "location.slash")!
+            setLargeImage = UIImage(systemName: "location.slash.fill")!
             setLabel = "Location services unavailable"
         case .impreciseLocation:
             setHidden = false
-            if #available(iOS 13.0, *) {
-                setImage = UIImage(systemName: "location.circle")!
-                setLargeImage = UIImage(systemName: "location.circle.fill")!
-            }
+            setImage = UIImage(systemName: "location.circle")!
+            setLargeImage = UIImage(systemName: "location.circle.fill")!
             setLabel = "Precise location unavailable"
         case .locationServicesOn:
             setHidden = true
@@ -155,10 +151,7 @@ class MapStatusView: UIView {
             self.stackView.isHidden = setHidden
             self.iconView.image = setImage
             self.detailLabel.text = setLabel
-
-            if #available(iOS 13.0, *) {
-                self.largeContentImage = setLargeImage
-            }
+            self.largeContentImage = setLargeImage
 
             self.layoutIfNeeded()
         }

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -95,7 +95,7 @@ public class MapViewController: UIViewController,
         ])
 
         mapStatusView.addInteraction(UILargeContentViewerInteraction(delegate: self))
-     
+
         floatingPanel.addPanel(toParent: self)
 
         view.insertSubview(toolbar, aboveSubview: mapView)

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -94,10 +94,8 @@ public class MapViewController: UIViewController,
             mapStatusView.topAnchor.constraint(equalTo: view.topAnchor)
         ])
 
-        if #available(iOS 13, *) {
-            mapStatusView.addInteraction(UILargeContentViewerInteraction(delegate: self))
-        }
-
+        mapStatusView.addInteraction(UILargeContentViewerInteraction(delegate: self))
+     
         floatingPanel.addPanel(toParent: self)
 
         view.insertSubview(toolbar, aboveSubview: mapView)
@@ -410,11 +408,9 @@ public class MapViewController: UIViewController,
     }
 
     func mapRegionManager(_ manager: MapRegionManager, customize stopAnnotationView: StopAnnotationView) {
-        if #available(iOS 13.0, *) {
-            if stopAnnotationView.interactions.count == 0 {
-                let interaction = UIContextMenuInteraction(delegate: self)
-                stopAnnotationView.addInteraction(interaction)
-            }
+        if stopAnnotationView.interactions.count == 0 {
+            let interaction = UIContextMenuInteraction(delegate: self)
+            stopAnnotationView.addInteraction(interaction)
         }
     }
 
@@ -470,12 +466,8 @@ public class MapViewController: UIViewController,
     lazy var loadingIndicator: UIActivityIndicatorView = {
         let indicator: UIActivityIndicatorView
 
-        if #available(iOS 13, *) {
-            indicator = UIActivityIndicatorView(style: .medium)
-            indicator.color = ThemeColors.shared.brand
-        } else {
-            indicator = UIActivityIndicatorView(style: .gray)
-        }
+        indicator = UIActivityIndicatorView(style: .medium)
+        indicator.color = ThemeColors.shared.brand
 
         indicator.hidesWhenStopped = true
         return indicator
@@ -567,7 +559,6 @@ public class MapViewController: UIViewController,
 
     // MARK: - Context Menus
 
-    @available(iOS 13.0, *)
     public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
         guard
             let annotationView = interaction.view as? MKAnnotationView,
@@ -583,7 +574,6 @@ public class MapViewController: UIViewController,
         return UIContextMenuConfiguration(identifier: nil, previewProvider: previewController, actionProvider: nil)
     }
 
-    @available(iOS 13.0, *)
     public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionCommitAnimating) {
         guard let viewController = animator.previewViewController else { return }
 
@@ -596,7 +586,6 @@ public class MapViewController: UIViewController,
         }
     }
 
-    @available(iOS 13, *)
     public func largeContentViewerInteraction(_ interaction: UILargeContentViewerInteraction, didEndOn item: UILargeContentViewerItem?, at point: CGPoint) {
         if mapStatusView.frame.contains(point) {
             didTapMapStatus(interaction)

--- a/OBAKit/Onboarding/DataMigrationBulletinPage.swift
+++ b/OBAKit/Onboarding/DataMigrationBulletinPage.swift
@@ -100,7 +100,7 @@ final class DataMigrationBulletinPage: ThemedBulletinPage {
     // MARK: - Progress Indicator
 
     private lazy var activityIndicator: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(style: .gray)
+        let indicator = UIActivityIndicatorView(style: .medium)
         indicator.translatesAutoresizingMaskIntoConstraints = false
         indicator.hidesWhenStopped = true
 

--- a/OBAKit/Orchestration/Application.swift
+++ b/OBAKit/Orchestration/Application.swift
@@ -311,7 +311,7 @@ public class Application: CoreApplication, PushServiceDelegate {
 
     /// Provides access the topmost view controller in the app, if one exists.
     private var topViewController: UIViewController? {
-        delegate?.uiApplication?.keyWindow?.topViewController
+        delegate?.uiApplication?.windows.first?.topViewController
     }
 
     @objc public func application(_ application: UIApplication, didFinishLaunching options: [AnyHashable: Any]) {

--- a/OBAKit/Stops/StopArrivalListItem.swift
+++ b/OBAKit/Stops/StopArrivalListItem.swift
@@ -108,7 +108,6 @@ final class StopArrivalSectionController: OBAListSectionController<ArrivalDepart
 
     // MARK: - Context Menu
 
-    @available(iOS 13.0, *)
     func contextMenuConfiguration(forItemAt indexPath: IndexPath) -> UIContextMenuConfiguration? {
         guard let sectionData = self.sectionData else { return nil }
         return delegate?.stopArrivalSectionController(self, contextMenuConfigurationFor: sectionData)

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -795,15 +795,8 @@ public class StopViewController: UIViewController,
 
     func serviceAlertsSectionController(_ controller: ServiceAlertsSectionController, didSelectAlert alert: ServiceAlert) {
         let serviceAlertController = ServiceAlertViewController(serviceAlert: alert, application: self.application)
-
-        // On iOS 13+, use the system sheet presentation.
-        // iOS 12 does not have the sheet presentation, so just push nav stack instead.
-        if #available(iOS 13, *) {
-            let nc = UINavigationController(rootViewController: serviceAlertController)
-            self.present(nc, animated: true)
-        } else {
-            self.application.viewRouter.navigate(to: serviceAlertController, from: self)
-        }
+        let nc = UINavigationController(rootViewController: serviceAlertController)
+        self.present(nc, animated: true)
     }
 
     // MARK: - Stop Arrival Actions

--- a/OBAKit/Theme/Icons.swift
+++ b/OBAKit/Theme/Icons.swift
@@ -74,14 +74,9 @@ class Icons: NSObject {
 
     /// A right-pointing chevron arrow, like the kind used as a disclosure indicator on a table cell.
     public class var chevron: UIImage {
-        let image = systemImage(named: "chevron.right", fallback: "chevron")
-        if #available(iOS 13, *) {
-            return image
+        return systemImage(named: "chevron.right", fallback: "chevron")
                 .withTintColor(.systemGray, renderingMode: .alwaysOriginal)
                 .withConfiguration(UIImage.SymbolConfiguration.init(weight: .bold))
-        } else {
-            return image
-        }
     }
 
     /// A checkmark icon.
@@ -241,32 +236,20 @@ class Icons: NSObject {
 
     // MARK: - Private Helpers
 
-    /// On iOS 13+, this applies the configuration used for generating tab bar icons. On iOS 12, this does nothing and returns its input.
+    /// This applies the configuration used for generating tab bar icons.
     private class func configureForTabIcon(_ image: UIImage) -> UIImage {
-        if #available(iOS 13, *) {
-            let config = UIImage.SymbolConfiguration(textStyle: .headline, scale: .medium)
-            return image.applyingSymbolConfiguration(config)!
-        } else {
-            return image
-        }
+        let config = UIImage.SymbolConfiguration(textStyle: .headline, scale: .medium)
+        return image.applyingSymbolConfiguration(config)!
     }
 
-    /// On iOS 13+, this applies the configuration used for generating button icons. On iOS 12, this does nothing and returns its input.
+    /// This applies the configuration used for generating button icons.
     private class func configureForButtonIcon(_ image: UIImage) -> UIImage {
-        if #available(iOS 13, *) {
-            return image.applyingSymbolConfiguration(.init(pointSize: 16))!
-        } else {
-            return image
-        }
+        return image.applyingSymbolConfiguration(.init(pointSize: 16))!
     }
 
     /// Tries to get the specified system image. If the image cannot be initialized, it will use the fallback name.
     private static func systemImage(named systemName: String, fallback: String) -> UIImage {
-        if #available(iOS 13, *) {
-            return UIImage(systemName: systemName) ?? imageNamed(fallback)
-        } else {
-            return imageNamed(fallback)
-        }
+        return UIImage(systemName: systemName) ?? imageNamed(fallback)
     }
 
     private static func imageNamed(_ name: String) -> UIImage {

--- a/OBAKit/ViewRouting/Router.swift
+++ b/OBAKit/ViewRouting/Router.swift
@@ -49,10 +49,7 @@ public class ViewRouter: NSObject, UINavigationControllerDelegate {
         popoverSourceFrame: CGRect? = nil,
         popoverBarButtonItem: UIBarButtonItem? = nil
     ) {
-        if #available(iOS 13.0, *) {
-            presentedController.isModalInPresentation = isModal
-        }
-
+        presentedController.isModalInPresentation = isModal
         if isPopover, let popover = presentedController.popoverPresentationController {
             if let popoverSourceFrame = popoverSourceFrame {
                 popover.sourceRect = popoverSourceFrame

--- a/OBAKitCore/Collections/ActivityIndicatedButton.swift
+++ b/OBAKitCore/Collections/ActivityIndicatedButton.swift
@@ -60,23 +60,15 @@ public class ActivityIndicatedButton: UIView {
         button.setTitleColor(ThemeColors.shared.brand, for: .normal)
         button.addTarget(self, action: #selector(buttonDidTap), for: .touchUpInside)
 
-        if #available(iOS 13, *) {
-            button.scalesLargeContentImage = true
-            button.showsLargeContentViewer = true
-            button.addInteraction(UILargeContentViewerInteraction())
-        }
+        button.scalesLargeContentImage = true
+        button.showsLargeContentViewer = true
+        button.addInteraction(UILargeContentViewerInteraction())
 
         return button
     }()
 
     fileprivate let activityIndicator: UIActivityIndicatorView = {
-        let activityIndicator: UIActivityIndicatorView
-        if #available(iOS 13.0, *) {
-            activityIndicator = UIActivityIndicatorView(style: .medium)
-        } else {
-            activityIndicator = UIActivityIndicatorView(style: .gray)
-        }
-
+        let activityIndicator = UIActivityIndicatorView(style: .medium)
         activityIndicator.hidesWhenStopped = true
         return activityIndicator
     }()
@@ -128,9 +120,7 @@ public class ActivityIndicatedButton: UIView {
         self.isHidden = self.config == nil
 
         self.button.setTitle(config?.text, for: .normal)
-        if #available(iOS 13.0, *) {
-            self.button.largeContentImage = config?.largeContentImage
-        }
+        self.button.largeContentImage = config?.largeContentImage
 
         self.layoutIfNeeded()
     }

--- a/OBAKitCore/Collections/EmptyDataSetView.swift
+++ b/OBAKitCore/Collections/EmptyDataSetView.swift
@@ -58,10 +58,7 @@ public class EmptyDataSetView: UIView {
         let imageView = UIImageView.autolayoutNew()
         imageView.tintColor = EmptyDataSetView.DefaultColor
         imageView.contentMode = .scaleAspectFit
-
-        if #available(iOS 13.0, *) {
-            imageView.preferredSymbolConfiguration = UIImage.SymbolConfiguration(scale: .large)
-        }
+        imageView.preferredSymbolConfiguration = UIImage.SymbolConfiguration(scale: .large)
 
         return imageView
     }()

--- a/OBAKitCore/Extensions/UIKitExtensions.swift
+++ b/OBAKitCore/Extensions/UIKitExtensions.swift
@@ -98,7 +98,7 @@ public extension UIColor {
         var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
 
-        var rgb: UInt32 = 0
+        var rgb: UInt64 = 0
 
         var r: CGFloat = 0.0
         var g: CGFloat = 0.0
@@ -107,7 +107,7 @@ public extension UIColor {
 
         let length = hexSanitized.count
 
-        guard Scanner(string: hexSanitized).scanHexInt32(&rgb) else { return nil }
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else { return nil }
 
         if length == 6 {
             r = CGFloat((rgb & 0xFF0000) >> 16) / 255.0

--- a/OBAKitCore/Theme/Theme.swift
+++ b/OBAKitCore/Theme/Theme.swift
@@ -9,8 +9,6 @@
 
 import UIKit
 
-// swiftlint:disable function_body_length
-
 public class ThemeMetrics: NSObject {
 
     public static let accessibilityPadding: CGFloat = 16.0

--- a/OBAKitCore/Theme/Theme.swift
+++ b/OBAKitCore/Theme/Theme.swift
@@ -127,73 +127,37 @@ public class ThemeColors: NSObject {
         brand = UIColor(named: "brand", in: bundle, compatibleWith: traitCollection)!
         mapSnapshotOverlayColor = UIColor(white: 0.0, alpha: 0.4)
 
-        if #available(iOS 13, *) {
-            departureEarly = .systemRed
-            departureEarlyBackground = .systemRed
+        departureEarly = .systemRed
+        departureEarlyBackground = .systemRed
 
-            departureOnTime = .systemGreen
-            departureOnTimeBackground = .systemGreen
+        departureOnTime = .systemGreen
+        departureOnTimeBackground = .systemGreen
 
-            departureUnknown = .label
-            departureUnknownBackground = .systemGray
+        departureUnknown = .label
+        departureUnknownBackground = .systemGray
 
-            departureLate = .systemBlue
-            departureLateBackground = .systemBlue
+        departureLate = .systemBlue
+        departureLateBackground = .systemBlue
 
-            gray = .systemGray
-            green = .systemGreen
-            blue = .systemBlue
-            groupedTableBackground = .systemGroupedBackground
-            groupedTableRowBackground = .white
-            systemBackground = .systemBackground
-            mapText = .label
-            label = .label
-            secondaryLabel = .secondaryLabel
-            separator = .separator
-            highlightedBackgroundColor = .systemFill
-            secondaryBackgroundColor = .secondarySystemBackground
-            propertyChanged = .systemYellow
+        gray = .systemGray
+        green = .systemGreen
+        blue = .systemBlue
+        groupedTableBackground = .systemGroupedBackground
+        groupedTableRowBackground = .white
+        systemBackground = .systemBackground
+        mapText = .label
+        label = .label
+        secondaryLabel = .secondaryLabel
+        separator = .separator
+        highlightedBackgroundColor = .systemFill
+        secondaryBackgroundColor = .secondarySystemBackground
+        propertyChanged = .systemYellow
 
-            stopAnnotationFillColor = .systemBackground
-            stopAnnotationStrokeColor = .label
-            stopArrowFillColor = .systemRed
-            systemFill = .systemFill
-            lightText = .white
-            errorColor = .systemRed
-        }
-        else {
-            departureEarly = UIColor(hex: "fc3f3b")!
-            departureEarlyBackground = departureEarly
-
-            departureOnTime = UIColor(hex: "16771a")!
-            departureOnTimeBackground = departureOnTime
-
-            departureUnknown = .black
-            departureUnknownBackground = .darkGray
-
-            departureLate = UIColor(hex: "0082f8")!
-            departureLateBackground = departureLate
-
-            gray = .gray
-            green = .green
-            blue = .blue
-            groupedTableBackground = .groupTableViewBackground
-            groupedTableRowBackground = .white
-            systemBackground = .white
-            mapText = UIColor(r: 42, g: 44, b: 47)
-            label = .black
-            secondaryLabel = .darkGray
-            separator = UIColor(red: 200 / 255.0, green: 199 / 255.0, blue: 204 / 255.0, alpha: 1)
-            highlightedBackgroundColor = UIColor(white: 0.9, alpha: 1)
-            secondaryBackgroundColor = UIColor(white: 0.9, alpha: 1)
-            propertyChanged = UIColor(r: 255, g: 255, b: 128)
-
-            stopAnnotationFillColor = .white
-            stopAnnotationStrokeColor = .black
-            stopArrowFillColor = .red
-            systemFill = UIColor(white: 0.9, alpha: 1)
-            lightText = .white
-            errorColor = .red
-        }
+        stopAnnotationFillColor = .systemBackground
+        stopAnnotationStrokeColor = .label
+        stopArrowFillColor = .systemRed
+        systemFill = .systemFill
+        lightText = .white
+        errorColor = .systemRed
     }
 }

--- a/OBAKitCore/UI/PaddingLabel.swift
+++ b/OBAKitCore/UI/PaddingLabel.swift
@@ -59,12 +59,7 @@ public class PaddingLabel: UILabel {
     }
 
     func configure() {
-        let isHighContrast: Bool
-        if #available(iOS 13, *) {
-            isHighContrast = traitCollection.accessibilityContrast == .high
-        } else {
-            isHighContrast = false
-        }
+        let isHighContrast = traitCollection.accessibilityContrast == .high
 
         if let backgroundColor = self.backgroundColor {
             self.layer.borderWidth = isHighContrast ? 4.0 : 0.0


### PR DESCRIPTION
I had a change of heart on supporting iOS 12. This is for two primary reasons:

1. I want to be able to use XCFrameworks (consume and publish).
2. I want to set us up to move off of IGListKit and onto the built-in diffable data sources feature at some point.

Furthermore, per Apple, 92% of devices released in the last four years are running iOS 13. https://developer.apple.com/support/app-store/

Thoughts, @ualch9?