### PR TITLE
Include Carthage frameworks for Xcode previews

### DIFF
--- a/OBAKit/project.yml
+++ b/OBAKit/project.yml
@@ -25,3 +25,13 @@ targets:
     settings:
       base:
         APPLICATION_EXTENSION_API_ONLY: false
+      configs:
+          Debug:
+            LD_RUNPATH_SEARCH_PATHS:
+              - "$(inherited)"
+              - "@executable_path/Frameworks"
+              - "$(PROJECT_DIR)/Carthage/Build/iOS"     # Fix for missing framework in Xcode Previews
+          Release:
+            LD_RUNPATH_SEARCH_PATHS:
+              - "$(inherited)"
+              - "@executable_path/Frameworks"


### PR DESCRIPTION
hotfix for missing carthage frameworks when xcode previewing App scheme.
I don't think its necessary to include this in RELEASE since everything builds and runs OK.