### PR TITLE
Recent Stops should only show stops from the current region

### DIFF
--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -128,7 +128,11 @@ public class RecentStopsViewController: UIViewController,
     }
 
     private var stopsSection: [ListDiffable] {
-        let stops = application.userDataStore.recentStops
+        guard let currentRegion = application.currentRegion else {
+            return []
+        }
+
+        let stops = application.userDataStore.recentStops.filter { $0.regionIdentifier == currentRegion.regionIdentifier }
         guard stops.count > 0 else {
             return []
         }

--- a/OBAKitCore/Location/Regions/RegionsService.swift
+++ b/OBAKitCore/Location/Regions/RegionsService.swift
@@ -244,7 +244,7 @@ public class RegionsService: NSObject, LocationServiceDelegate {
 
     private static func bundledRegions(path: String) -> [Region] {
         let data = try! NSData(contentsOfFile: path) as Data
-        let response = try! JSONDecoder.RESTDecoder.decode(RESTAPIResponse<[Region]>.self, from: data)
+        let response = try! JSONDecoder.RESTDecoder().decode(RESTAPIResponse<[Region]>.self, from: data)
         return response.list
     }
 
@@ -257,7 +257,7 @@ public class RegionsService: NSObject, LocationServiceDelegate {
     public func updateRegionsList(forceUpdate: Bool = false) {
         // only update once per week, unless forceUpdate is true.
         if let lastUpdatedAt = userDefaults.object(forKey: RegionsService.regionsUpdatedAtUserDefaultsKey) as? Date,
-           abs(lastUpdatedAt.timeIntervalSinceNow) < 604800,
+           abs(lastUpdatedAt.timeIntervalSinceNow) < 604800, // Seconds in a day.
            !forceUpdate
         { // swiftlint:disable:this opening_brace
             notifyDelegatesRegionListUpdateCancelled()

--- a/OBAKitCore/Models/Helpers/InternalTypes.swift
+++ b/OBAKitCore/Models/Helpers/InternalTypes.swift
@@ -42,8 +42,11 @@ extension JSONDecoder {
         return decoder
     }
 
-    class var RESTDecoder: JSONDecoder {
+    class func RESTDecoder(regionIdentifier: Int? = nil) -> JSONDecoder {
         let decoder = JSONDecoder()
+        if let regionIdentifier = regionIdentifier {
+            decoder.userInfo = [References.regionIdentifierUserInfoKey: regionIdentifier]
+        }
         decoder.dateDecodingStrategy = .millisecondsSince1970
         return decoder
     }

--- a/OBAKitCore/Models/REST/AgencyWithCoverage.swift
+++ b/OBAKitCore/Models/REST/AgencyWithCoverage.swift
@@ -15,6 +15,7 @@ public class AgencyWithCoverage: NSObject, Decodable, HasReferences {
     public let agencyID: String
     public var agency: Agency!
     public let region: MKCoordinateRegion
+    public private(set) var regionIdentifier: Int?
 
     private enum CodingKeys: String, CodingKey {
         case agencyID = "agencyId"
@@ -36,13 +37,15 @@ public class AgencyWithCoverage: NSObject, Decodable, HasReferences {
         region = MKCoordinateRegion(center: coordinate, latitudinalMeters: latSpan, longitudinalMeters: lonSpan)
     }
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         agency = references.agencyWithID(agencyID)
+        self.regionIdentifier = regionIdentifier
     }
 
     public override var debugDescription: String {
         var descriptionBuilder = DebugDescriptionBuilder(baseDescription: super.debugDescription)
         descriptionBuilder.add(key: "agency", value: agency)
+        descriptionBuilder.add(key: "regionIdentifier", value: regionIdentifier)
         return descriptionBuilder.description
     }
 }

--- a/OBAKitCore/Models/REST/ArrivalDeparture.swift
+++ b/OBAKitCore/Models/REST/ArrivalDeparture.swift
@@ -100,6 +100,8 @@ public class ArrivalDeparture: NSObject, Decodable, HasReferences {
     /// The ID of the arriving transit vehicle
     public let vehicleID: String?
 
+    public private(set) var regionIdentifier: Int?
+
     private enum CodingKeys: String, CodingKey {
         case arrivalEnabled
         case blockTripSequence
@@ -178,12 +180,13 @@ public class ArrivalDeparture: NSObject, Decodable, HasReferences {
 
     // MARK: - HasReferences
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         route = references.routeWithID(routeID)!
         serviceAlerts = references.serviceAlertsWithIDs(situationIDs)
         stop = references.stopWithID(stopID)!
         trip = references.tripWithID(tripID)!
-        tripStatus?.loadReferences(references)
+        tripStatus?.loadReferences(references, regionIdentifier: regionIdentifier)
+        self.regionIdentifier = regionIdentifier
     }
 
     // MARK: - Helpers/Names
@@ -312,10 +315,6 @@ public class ArrivalDeparture: NSObject, Decodable, HasReferences {
 
     // MARK: - Equality and Hashing
 
-    // TODO: Implement isEqual and hash on Trip and TripStatus,
-    // and add those members back in to the methods below.
-    // https://github.com/aaronbrethorst/OBAKit/issues/116
-
     public override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? ArrivalDeparture else { return false }
         return
@@ -329,6 +328,7 @@ public class ArrivalDeparture: NSObject, Decodable, HasReferences {
             predicted == rhs.predicted &&
             predictedArrival == rhs.predictedArrival &&
             predictedDeparture == rhs.predictedDeparture &&
+            regionIdentifier == rhs.regionIdentifier &&
             routeID == rhs.routeID &&
             route == rhs.route &&
             _routeLongName == rhs._routeLongName &&
@@ -362,6 +362,7 @@ public class ArrivalDeparture: NSObject, Decodable, HasReferences {
         hasher.combine(predicted)
         hasher.combine(predictedArrival)
         hasher.combine(predictedDeparture)
+        hasher.combine(regionIdentifier)
         hasher.combine(routeID)
         hasher.combine(route)
         hasher.combine(_routeLongName)
@@ -397,6 +398,7 @@ public class ArrivalDeparture: NSObject, Decodable, HasReferences {
         builder.add(key: "predicted", value: predicted)
         builder.add(key: "predictedArrival", value: predictedArrival)
         builder.add(key: "predictedDeparture", value: predictedDeparture)
+        builder.add(key: "regionIdentifier", value: regionIdentifier)
         builder.add(key: "routeID", value: routeID)
         builder.add(key: "scheduledArrival", value: scheduledArrival)
         builder.add(key: "scheduledDeparture", value: scheduledDeparture)

--- a/OBAKitCore/Models/REST/RESTAPIResponse.swift
+++ b/OBAKitCore/Models/REST/RESTAPIResponse.swift
@@ -69,8 +69,10 @@ public class RESTAPIResponse<T>: CoreRESTAPIResponse where T: Decodable {
 
         references = try dataContainer.decodeIfPresent(References.self, forKey: .references)
 
+        let regionIdentifier = decoder.userInfo[References.regionIdentifierUserInfoKey] as? Int
+
         if let list = list as? HasReferences, let references = references {
-            list.loadReferences(references)
+            list.loadReferences(references, regionIdentifier: regionIdentifier)
         }
 
         limitExceeded = try dataContainer.decodeIfPresent(Bool.self, forKey: .limitExceeded)

--- a/OBAKitCore/Models/REST/References/References.swift
+++ b/OBAKitCore/Models/REST/References/References.swift
@@ -16,6 +16,10 @@ public class References: NSObject, Decodable {
     public let stops: [Stop]
     public let trips: [Trip]
 
+    static var regionIdentifierUserInfoKey: CodingUserInfoKey {
+        return CodingUserInfoKey(rawValue: "regionIdentifier")!
+    }
+
     // MARK: - Initialization
 
     private enum CodingKeys: String, CodingKey {
@@ -45,28 +49,33 @@ public class References: NSObject, Decodable {
 
         super.init()
 
+        let regionIdentifier = decoder.userInfo[References.regionIdentifierUserInfoKey] as? Int
+
         // depends: Agency, Route, Stop, Trip
-        serviceAlerts.loadReferences(self)
+        serviceAlerts.loadReferences(self, regionIdentifier: regionIdentifier)
 
         // depends: Agency
-        routes.loadReferences(self)
+        routes.loadReferences(self, regionIdentifier: regionIdentifier)
 
         // depends: Route
-        stops.loadReferences(self)
-        trips.loadReferences(self)
+        stops.loadReferences(self, regionIdentifier: regionIdentifier)
+        trips.loadReferences(self, regionIdentifier: regionIdentifier)
     }
 }
 
 // MARK: - HasReferences
 
 public protocol HasReferences {
-    func loadReferences(_ references: References)
+    func loadReferences(_ references: References, regionIdentifier: Int?)
+    var regionIdentifier: Int? { get }
 }
 
 extension Array: HasReferences where Element: HasReferences {
-    public func loadReferences(_ references: References) {
+    public var regionIdentifier: Int? { first?.regionIdentifier }
+
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         for elt in self {
-            elt.loadReferences(references)
+            elt.loadReferences(references, regionIdentifier: regionIdentifier)
         }
     }
 }

--- a/OBAKitCore/Models/REST/References/ServiceAlert.swift
+++ b/OBAKitCore/Models/REST/References/ServiceAlert.swift
@@ -35,6 +35,8 @@ public class ServiceAlert: NSObject, Decodable, HasReferences {
     public let summary: TranslatedString
     public let urlString: TranslatedString?
 
+    public private(set) var regionIdentifier: Int?
+
     enum CodingKeys: String, CodingKey {
         case activeWindows
         case affectedEntities = "allAffects"
@@ -75,6 +77,7 @@ public class ServiceAlert: NSObject, Decodable, HasReferences {
             situationDescription == rhs.situationDescription &&
             id == rhs.id &&
             publicationWindows == rhs.publicationWindows &&
+            regionIdentifier == rhs.regionIdentifier &&
             reason == rhs.reason &&
             severity == rhs.severity &&
             summary == rhs.summary &&
@@ -87,11 +90,12 @@ public class ServiceAlert: NSObject, Decodable, HasReferences {
         hasher.combine(affectedEntities)
         hasher.combine(consequences)
         hasher.combine(createdAt)
-        hasher.combine(situationDescription)
         hasher.combine(id)
         hasher.combine(publicationWindows)
         hasher.combine(reason)
+        hasher.combine(regionIdentifier)
         hasher.combine(severity)
+        hasher.combine(situationDescription)
         hasher.combine(summary)
         hasher.combine(urlString)
         return hasher.finalize()
@@ -99,11 +103,12 @@ public class ServiceAlert: NSObject, Decodable, HasReferences {
 
     // MARK: - HasReferences
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         affectedAgencies = Set<Agency>(affectedEntities.compactMap { references.agencyWithID($0.agencyID) })
         affectedRoutes = Set<Route>(affectedEntities.compactMap { references.routeWithID($0.routeID) })
         affectedStops = Set<Stop>(affectedEntities.compactMap { references.stopWithID($0.stopID) })
         affectedTrips = Set<Trip>(affectedEntities.compactMap { references.tripWithID($0.tripID) })
+        self.regionIdentifier = regionIdentifier
     }
 
     // MARK: - TimeWindow

--- a/OBAKitCore/Models/REST/References/Trip.swift
+++ b/OBAKitCore/Models/REST/References/Trip.swift
@@ -59,6 +59,8 @@ public class Trip: NSObject, Decodable, HasReferences {
     /// Use this field to distinguish between different patterns of service in the same route.
     public let headsign: String?
 
+    public private(set) var regionIdentifier: Int?
+
     private enum CodingKeys: String, CodingKey {
         case blockID = "blockId"
         case direction
@@ -88,8 +90,9 @@ public class Trip: NSObject, Decodable, HasReferences {
 
     // MARK: - HasReferences
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         route = references.routeWithID(routeID)
+        self.regionIdentifier = regionIdentifier
     }
 
     // MARK: - Route Descriptions
@@ -111,6 +114,7 @@ public class Trip: NSObject, Decodable, HasReferences {
             direction == rhs.direction &&
             headsign == rhs.headsign &&
             id == rhs.id &&
+            regionIdentifier == rhs.regionIdentifier &&
             routeID == rhs.routeID &&
             routeShortName == rhs.routeShortName &&
             serviceID == rhs.serviceID &&
@@ -125,6 +129,7 @@ public class Trip: NSObject, Decodable, HasReferences {
         hasher.combine(direction)
         hasher.combine(headsign)
         hasher.combine(id)
+        hasher.combine(regionIdentifier)
         hasher.combine(routeID)
         hasher.combine(routeShortName)
         hasher.combine(serviceID)

--- a/OBAKitCore/Models/REST/StopArrivals.swift
+++ b/OBAKitCore/Models/REST/StopArrivals.swift
@@ -42,6 +42,8 @@ public class StopArrivals: NSObject, Decodable, HasReferences {
     /// The stop to which this object refers.
     public var stop: Stop!
 
+    public private(set) var regionIdentifier: Int?
+
     private enum CodingKeys: String, CodingKey {
         case arrivalsAndDepartures
         case nearbyStopIDs = "nearbyStopIds"
@@ -58,10 +60,11 @@ public class StopArrivals: NSObject, Decodable, HasReferences {
         stopID = try container.decode(StopID.self, forKey: .stopID)
     }
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         nearbyStops = references.stopsWithIDs(nearbyStopIDs)
         _serviceAlerts = references.serviceAlertsWithIDs(situationIDs)
         stop = references.stopWithID(stopID)!
-        arrivalsAndDepartures.loadReferences(references)
+        arrivalsAndDepartures.loadReferences(references, regionIdentifier: regionIdentifier)
+        self.regionIdentifier = regionIdentifier
     }
 }

--- a/OBAKitCore/Models/REST/StopsForRoute.swift
+++ b/OBAKitCore/Models/REST/StopsForRoute.swift
@@ -38,6 +38,8 @@ public class StopsForRoute: NSObject, Decodable, HasReferences {
     let stopIDs: [String]
     public private(set) var stops: [Stop]!
 
+    public private(set) var regionIdentifier: Int?
+
     public let stopGroupings: [StopGrouping]
 
     private enum CodingKeys: String, CodingKey {
@@ -58,10 +60,11 @@ public class StopsForRoute: NSObject, Decodable, HasReferences {
 
     // MARK: - HasReferences
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         route = references.routeWithID(routeID)!
         stops = references.stopsWithIDs(stopIDs)
-        stopGroupings.loadReferences(references)
+        stopGroupings.loadReferences(references, regionIdentifier: regionIdentifier)
+        self.regionIdentifier = regionIdentifier
     }
 
     // MARK: - Nested Types
@@ -72,6 +75,8 @@ public class StopsForRoute: NSObject, Decodable, HasReferences {
         public let ordered: Bool
         public let groupingType: String
         public let stopGroups: [StopGroup]
+
+        public private(set) var regionIdentifier: Int?
 
         private enum CodingKeys: String, CodingKey {
             case ordered
@@ -86,8 +91,9 @@ public class StopsForRoute: NSObject, Decodable, HasReferences {
             stopGroups = try container.decode([StopGroup].self, forKey: .stopGroups)
         }
 
-        public func loadReferences(_ references: References) {
-            stopGroups.loadReferences(references)
+        public func loadReferences(_ references: References, regionIdentifier: Int?) {
+            stopGroups.loadReferences(references, regionIdentifier: regionIdentifier)
+            self.regionIdentifier = regionIdentifier
         }
     }
 
@@ -101,6 +107,8 @@ public class StopsForRoute: NSObject, Decodable, HasReferences {
 
         let stopIDs: [String]
         public private(set) var stops = [Stop]()
+
+        public private(set) var regionIdentifier: Int?
 
         private enum CodingKeys: String, CodingKey {
             case id
@@ -125,8 +133,9 @@ public class StopsForRoute: NSObject, Decodable, HasReferences {
             stopIDs = try container.decode([String].self, forKey: .stopIDs)
         }
 
-        public func loadReferences(_ references: References) {
+        public func loadReferences(_ references: References, regionIdentifier: Int?) {
             stops = references.stopsWithIDs(stopIDs)
+            self.regionIdentifier = regionIdentifier
         }
     }
 }

--- a/OBAKitCore/Models/REST/TripDetails.swift
+++ b/OBAKitCore/Models/REST/TripDetails.swift
@@ -50,6 +50,8 @@ public class TripDetails: NSObject, Decodable, HasReferences {
     /// Contains any active `ServiceAlert` elements that currently apply to the trip.
     public private(set) var serviceAlerts = [ServiceAlert]()
 
+    public private(set) var regionIdentifier: Int?
+
     private enum CodingKeys: String, CodingKey {
         case frequency
         case tripID = "tripId"
@@ -85,12 +87,13 @@ public class TripDetails: NSObject, Decodable, HasReferences {
 
     // MARK: - HasReferences
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         trip = references.tripWithID(tripID)!
         previousTrip = references.tripWithID(previousTripID)
         nextTrip = references.tripWithID(nextTripID)
         serviceAlerts = references.serviceAlertsWithIDs(situationIDs)
-        stopTimes.loadReferences(references)
-        status?.loadReferences(references)
+        stopTimes.loadReferences(references, regionIdentifier: regionIdentifier)
+        status?.loadReferences(references, regionIdentifier: regionIdentifier)
+        self.regionIdentifier = regionIdentifier
     }
 }

--- a/OBAKitCore/Models/REST/TripStatus.swift
+++ b/OBAKitCore/Models/REST/TripStatus.swift
@@ -133,6 +133,8 @@ public class TripStatus: NSObject, Decodable, HasReferences {
     /// If real-time arrival info is available, this lists the id of the transit vehicle currently running the trip.
     public let vehicleID: String?
 
+    public private(set) var regionIdentifier: Int?
+
     private enum CodingKeys: String, CodingKey {
         case activeTripID = "activeTripId"
         case blockTripSequence
@@ -189,11 +191,12 @@ public class TripStatus: NSObject, Decodable, HasReferences {
         vehicleID = try container.decodeIfPresent(String.self, forKey: .vehicleID)
     }
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         activeTrip = references.tripWithID(activeTripID)!
         closestStop = references.stopWithID(closestStopID)!
         nextStop = references.stopWithID(nextStopID)
         serviceAlerts = references.serviceAlertsWithIDs(situationIDs)
+        self.regionIdentifier = regionIdentifier
     }
 
     // MARK: - Equality
@@ -201,31 +204,32 @@ public class TripStatus: NSObject, Decodable, HasReferences {
     public override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? TripStatus else { return false }
         return
-            activeTripID == rhs.activeTripID &&
             activeTrip == rhs.activeTrip &&
+            activeTripID == rhs.activeTripID &&
             blockTripSequence == rhs.blockTripSequence &&
-            closestStopID == rhs.closestStopID &&
             closestStop == rhs.closestStop &&
+            closestStopID == rhs.closestStopID &&
             closestStopTimeOffset == rhs.closestStopTimeOffset &&
             distanceAlongTrip == rhs.distanceAlongTrip &&
             frequency == rhs.frequency &&
+            isRealTime == rhs.isRealTime &&
             lastKnownDistanceAlongTrip == rhs.lastKnownDistanceAlongTrip &&
             lastKnownLocation == rhs.lastKnownLocation &&
             lastKnownOrientation == rhs.lastKnownOrientation &&
             lastLocationUpdateTime == rhs.lastLocationUpdateTime &&
             lastUpdate == rhs.lastUpdate &&
-            nextStopID == rhs.nextStopID &&
             nextStop == rhs.nextStop &&
+            nextStopID == rhs.nextStopID &&
             nextStopTimeOffset == rhs.nextStopTimeOffset &&
             orientation == rhs.orientation &&
             phase == rhs.phase &&
             position == rhs.position &&
-            isRealTime == rhs.isRealTime &&
+            regionIdentifier == rhs.regionIdentifier &&
             scheduleDeviation == rhs.scheduleDeviation &&
             scheduledDistanceAlongTrip == rhs.scheduledDistanceAlongTrip &&
+            serviceAlerts == rhs.serviceAlerts &&
             serviceDate == rhs.serviceDate &&
             situationIDs == rhs.situationIDs &&
-            serviceAlerts == rhs.serviceAlerts &&
             statusModifier == rhs.statusModifier &&
             totalDistanceAlongTrip == rhs.totalDistanceAlongTrip &&
             vehicleID == rhs.vehicleID
@@ -233,31 +237,32 @@ public class TripStatus: NSObject, Decodable, HasReferences {
 
     override public var hash: Int {
         var hasher = Hasher()
-        hasher.combine(activeTripID)
         hasher.combine(activeTrip)
+        hasher.combine(activeTripID)
         hasher.combine(blockTripSequence)
-        hasher.combine(closestStopID)
         hasher.combine(closestStop)
+        hasher.combine(closestStopID)
         hasher.combine(closestStopTimeOffset)
         hasher.combine(distanceAlongTrip)
         hasher.combine(frequency)
+        hasher.combine(isRealTime)
         hasher.combine(lastKnownDistanceAlongTrip)
         hasher.combine(lastKnownLocation)
         hasher.combine(lastKnownOrientation)
         hasher.combine(lastLocationUpdateTime)
         hasher.combine(lastUpdate)
-        hasher.combine(nextStopID)
         hasher.combine(nextStop)
+        hasher.combine(nextStopID)
         hasher.combine(nextStopTimeOffset)
         hasher.combine(orientation)
         hasher.combine(phase)
         hasher.combine(position)
-        hasher.combine(isRealTime)
+        hasher.combine(regionIdentifier)
         hasher.combine(scheduleDeviation)
         hasher.combine(scheduledDistanceAlongTrip)
+        hasher.combine(serviceAlerts)
         hasher.combine(serviceDate)
         hasher.combine(situationIDs)
-        hasher.combine(serviceAlerts)
         hasher.combine(statusModifier)
         hasher.combine(totalDistanceAlongTrip)
         hasher.combine(vehicleID)

--- a/OBAKitCore/Models/REST/TripStopTime.swift
+++ b/OBAKitCore/Models/REST/TripStopTime.swift
@@ -34,6 +34,8 @@ public class TripStopTime: NSObject, Decodable, HasReferences {
         }
     }
 
+    public private(set) var regionIdentifier: Int?
+
     private enum CodingKeys: String, CodingKey {
         case arrival = "arrivalTime"
         case departure = "departureTime"
@@ -54,6 +56,7 @@ public class TripStopTime: NSObject, Decodable, HasReferences {
         return
             arrival == rhs.arrival &&
             departure == rhs.departure &&
+            regionIdentifier == rhs.regionIdentifier &&
             stopID == rhs.stopID
     }
 
@@ -61,11 +64,13 @@ public class TripStopTime: NSObject, Decodable, HasReferences {
         var hasher = Hasher()
         hasher.combine(arrival)
         hasher.combine(departure)
+        hasher.combine(regionIdentifier)
         hasher.combine(stopID)
         return hasher.finalize()
     }
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         stop = references.stopWithID(stopID)!
+        self.regionIdentifier = regionIdentifier
     }
 }

--- a/OBAKitCore/Models/REST/VehicleStatus.swift
+++ b/OBAKitCore/Models/REST/VehicleStatus.swift
@@ -39,6 +39,8 @@ public class VehicleStatus: NSObject, Decodable, HasReferences {
     /// Provides additional status information for the vehicle's trip.
     public let tripStatus: TripStatus
 
+    public private(set) var regionIdentifier: Int?
+
     private enum CodingKeys: String, CodingKey {
         case vehicleID = "vehicleId"
         case lastUpdateTime = "lastUpdateTime"
@@ -71,8 +73,9 @@ public class VehicleStatus: NSObject, Decodable, HasReferences {
         tripStatus = try container.decode(TripStatus.self, forKey: .tripStatus)
     }
 
-    public func loadReferences(_ references: References) {
+    public func loadReferences(_ references: References, regionIdentifier: Int?) {
         trip = references.tripWithID(tripID)
-        tripStatus.loadReferences(references)
+        tripStatus.loadReferences(references, regionIdentifier: regionIdentifier)
+        self.regionIdentifier = regionIdentifier
     }
 }

--- a/OBAKitCore/Network/APIService.swift
+++ b/OBAKitCore/Network/APIService.swift
@@ -20,7 +20,7 @@ public class APIService: NSObject {
     let defaultQueryItems: [URLQueryItem]
     let dataLoader: URLDataLoader
 
-    /// Creates a new instance of APIService.
+    /// Creates a new instance of `APIService`.
     /// - Parameters:
     ///   - baseURL: The base URL for the service you will be using.
     ///   - apiKey: The API key for the service you will be using. Passed along as `key` in query params.

--- a/OBAKitCore/Network/RESTAPIService.swift
+++ b/OBAKitCore/Network/RESTAPIService.swift
@@ -15,8 +15,24 @@ import MapKit
 public class RESTAPIService: APIService {
     lazy var URLBuilder = RESTAPIURLBuilder(baseURL: baseURL, defaultQueryItems: defaultQueryItems)
 
+    private let regionIdentifier: Int
+
+    /// Creates a new instance of `RESTAPIService`.
+    /// - Parameters:
+    ///   - baseURL: The base URL for the service you will be using.
+    ///   - apiKey: The API key for the service you will be using. Passed along as `key` in query params.
+    ///   - uuid: A unique, anonymous user ID.
+    ///   - appVersion: The version of the app making the request.
+    ///   - networkQueue: The queue on which all network operations will be performed.
+    ///   - dataLoader: The object used to perform network operations. A protocol facade is provided here to simplify testing.
+    ///   - regionIdentifier: The unique ID of the `Region` that this service object is tied to.
+    public init(baseURL: URL, apiKey: String, uuid: String, appVersion: String, networkQueue: OperationQueue, dataLoader: URLDataLoader, regionIdentifier: Int) {
+        self.regionIdentifier = regionIdentifier
+        super.init(baseURL: baseURL, apiKey: apiKey, uuid: uuid, appVersion: appVersion, networkQueue: networkQueue, dataLoader: dataLoader)
+    }
+
     private func buildOperation<T>(type: T.Type, URL: URL) -> DecodableOperation<T> where T: Decodable {
-        return DecodableOperation(type: type, decoder: JSONDecoder.RESTDecoder, URL: URL, dataLoader: dataLoader)
+        return DecodableOperation(type: type, decoder: JSONDecoder.RESTDecoder(regionIdentifier: regionIdentifier), URL: URL, dataLoader: dataLoader)
     }
 
     // MARK: - Vehicle with ID

--- a/OBAKitCore/Network/RegionsAPIService.swift
+++ b/OBAKitCore/Network/RegionsAPIService.swift
@@ -14,7 +14,7 @@ public class RegionsAPIService: APIService {
 
     public func getRegions(apiPath: String) -> DecodableOperation<RESTAPIResponse<[Region]>> {
         let url = URLBuilder.generateURL(path: apiPath)
-        let operation = DecodableOperation(type: RESTAPIResponse<[Region]>.self, decoder: JSONDecoder.RESTDecoder, URL: url, dataLoader: dataLoader)
+        let operation = DecodableOperation(type: RESTAPIResponse<[Region]>.self, decoder: JSONDecoder.RESTDecoder(), URL: url, dataLoader: dataLoader)
         enqueueOperation(operation)
         return operation
     }

--- a/OBAKitCore/Orchestration/CoreApplication.swift
+++ b/OBAKitCore/Orchestration/CoreApplication.swift
@@ -112,7 +112,7 @@ open class CoreApplication: NSObject,
             return
         }
 
-        self.restAPIService = RESTAPIService(baseURL: region.OBABaseURL, apiKey: config.apiKey, uuid: userUUID, appVersion: config.appVersion, networkQueue: config.queue, dataLoader: config.dataLoader)
+        self.restAPIService = RESTAPIService(baseURL: region.OBABaseURL, apiKey: config.apiKey, uuid: userUUID, appVersion: config.appVersion, networkQueue: config.queue, dataLoader: config.dataLoader, regionIdentifier: region.regionIdentifier)
     }
 
     // MARK: - Obaco

--- a/OBAKitTests/Helpers/Fixtures.swift
+++ b/OBAKitTests/Helpers/Fixtures.swift
@@ -52,7 +52,7 @@ class Fixtures {
 
     class func loadRESTAPIPayload<T>(type: T.Type, fileName: String) throws -> T where T: Decodable {
         let data = loadData(file: fileName)
-        let apiResponse = try! JSONDecoder.RESTDecoder.decode(RESTAPIResponse<T>.self, from: data)
+        let apiResponse = try! JSONDecoder.RESTDecoder().decode(RESTAPIResponse<T>.self, from: data)
         return apiResponse.list
     }
 

--- a/OBAKitTests/Helpers/OBATestCase.swift
+++ b/OBAKitTests/Helpers/OBATestCase.swift
@@ -84,6 +84,8 @@ open class OBATestCase: XCTestCase {
 
     // MARK: - Network/REST API Service
 
+    let pugetSoundRegionIdentifier = 1
+
     var host: String { "www.example.com" }
 
     var baseURL: URL { URL(string: "https://\(host)")! }
@@ -97,7 +99,8 @@ open class OBATestCase: XCTestCase {
             uuid: uuid,
             appVersion: appVersion,
             networkQueue: networkQueue ?? OperationQueue(),
-            dataLoader: dataLoader ?? MockDataLoader(testName: name)
+            dataLoader: dataLoader ?? MockDataLoader(testName: name),
+            regionIdentifier: pugetSoundRegionIdentifier
         )
     }
 

--- a/OBAKitTests/Modeling/Model Unit Tests/ReferencesTests.swift
+++ b/OBAKitTests/Modeling/Model Unit Tests/ReferencesTests.swift
@@ -18,10 +18,12 @@ import CoreLocation
 class ReferencesTests: OBATestCase {
     var references: References!
 
+    let tampaRegionIdentifier = 0
+
     override func setUp() {
         super.setUp()
         let data = Fixtures.loadData(file: "references.json")
-        references = try! JSONDecoder.RESTDecoder.decode(References.self, from: data)
+        references = try! JSONDecoder.RESTDecoder(regionIdentifier: tampaRegionIdentifier).decode(References.self, from: data)
     }
 
     // MARK: - Agencies
@@ -61,13 +63,14 @@ class ReferencesTests: OBATestCase {
         expect(route.textColor).to(beCloseTo(UIColor.white))
         expect(route.routeType) == .bus
         expect(route.routeURL) == URL(string: "http://www.gohart.org/routes/hart/01.html")!
+        expect(route.regionIdentifier) == 0
     }
 
     // MARK: - Service Alerts
 
     func test_serviceAlerts_success() {
         let data = Fixtures.loadData(file: "arrival-and-departure-for-stop-MTS_11589.json")
-        let response = try! JSONDecoder.RESTDecoder.decode(RESTAPIResponse<ArrivalDeparture>.self, from: data)
+        let response = try! JSONDecoder.RESTDecoder().decode(RESTAPIResponse<ArrivalDeparture>.self, from: data)
         let situations = response.references!.serviceAlerts
 
         expect(situations.count) == 1

--- a/OBAKitTests/Modeling/REST Model Service Tests/StopsModelOperationTests.swift
+++ b/OBAKitTests/Modeling/REST Model Service Tests/StopsModelOperationTests.swift
@@ -48,11 +48,10 @@ class StopsModelOperationTests: OBATestCase {
         expect(stop.location.coordinate.longitude).to(beCloseTo(-122.312164))
         expect(stop.locationType) == .stop
         expect(stop.name) == "15th Ave NE & NE Campus Pkwy"
-
         expect(stop.routes.count) == 12
         expect(stop.routes.first!.id) == "1_100059"     // Test that routes get sorted by ID.
-
         expect(stop.wheelchairBoarding) == .unknown
+        expect(stop.regionIdentifier) == pugetSoundRegionIdentifier
     }
 
     func testLoading_coordinate_success() {


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/OBAKit/issues/282

* Adds a `regionIdentifier` value to RESTAPIService
* Plumbs `regionIdentifier` into core REST API models
* Filters Recent Stops controller's stops to only the current region
* Updates tests