### PR TITLE
Fixes Xcode automatic preview updating not working

### DIFF
--- a/Apps/Shared/app_shared.yml
+++ b/Apps/Shared/app_shared.yml
@@ -53,6 +53,7 @@ targets:
     preBuildScripts:
       - name: Versioning
         script: "${PROJECT_DIR}/scripts/version"
+        runOnlyWhenInstalling: true         # For SwiftUI Xcode Previews.
     scheme:
       gatherCoverageData: true
       testTargets:


### PR DESCRIPTION
Automatic preview updating doesn’t work when a script causes a major change, so now the “major change” only occurs on Install only.