### PR TITLE
Add a debug setting to turn off the week-long Region refresh interval

### DIFF
--- a/OBAKit/Settings/SettingsViewController.swift
+++ b/OBAKit/Settings/SettingsViewController.swift
@@ -42,6 +42,10 @@ class SettingsViewController: FormViewController {
             form +++ privacySection
         }
 
+        if application.userDataStore.debugMode {
+            form +++ debugSection
+        }
+
         if application.hasDataToMigrate {
             form +++ migrateDataSection
         }
@@ -51,7 +55,8 @@ class SettingsViewController: FormViewController {
             mapSectionShowsTraffic: application.mapRegionManager.mapViewShowsTraffic,
             mapSectionShowsHeading: application.mapRegionManager.mapViewShowsHeading,
             privacySectionReportingEnabled: application.analytics?.reportingEnabled?() ?? false,
-            AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts: application.userDefaults.bool(forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts)
+            AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts: application.userDefaults.bool(forKey: AgencyAlertsStore.UserDefaultKeys.displayRegionalTestAlerts),
+            RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey: application.userDefaults.bool(forKey: RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey)
         ])
     }
 
@@ -84,6 +89,10 @@ class SettingsViewController: FormViewController {
 
         if let reportingEnabled = values[privacySectionReportingEnabled] as? Bool {
             application.analytics?.setReportingEnabled?(reportingEnabled)
+        }
+
+        if let alwaysRefreshRegions = values[RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey] as? Bool {
+            application.userDefaults.set(alwaysRefreshRegions, forKey: RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey)
         }
     }
 
@@ -137,6 +146,19 @@ class SettingsViewController: FormViewController {
         section <<< SwitchRow {
             $0.tag = privacySectionReportingEnabled
             $0.title = OBALoc("settings_controller.privacy_section.reporting_enabled", value: "Send usage data to developer", comment: "Settings > Privacy section > Send usage data")
+        }
+
+        return section
+    }()
+
+    // MARK: - Debug Section
+
+    private lazy var debugSection: Section = {
+        let section = Section(OBALoc("settings_controller.debug_section.title", value: "Debug", comment: "Settings > Debug section title"))
+
+        section <<< SwitchRow {
+            $0.tag = RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey
+            $0.title = OBALoc("settings_controller.debug_section.always_refresh_regions", value: "Refresh regions on every launch", comment: "Settings > Debug section > Refresh regions on every launch")
         }
 
         return section

--- a/OBAKitTests/Location/RegionsServiceTests.swift
+++ b/OBAKitTests/Location/RegionsServiceTests.swift
@@ -187,6 +187,23 @@ class RegionsServiceTests: OBATestCase {
         }
     }
 
+    /// It *does* download a list of regions—even if the list was last updated less than a week ago—if alwaysRefreshRegionsOnLaunchUserDefaultsKey is true.
+    func test_init_alwaysRefreshRegionsOnLaunch() {
+        stubRegionsJustPugetSound(dataLoader: dataLoader)
+        userDefaults.set(Date(), forKey: RegionsService.regionsUpdatedAtUserDefaultsKey)
+        userDefaults.set(true, forKey: RegionsService.alwaysRefreshRegionsOnLaunchUserDefaultsKey)
+
+        let regionsService = RegionsService(apiService: regionsAPIService, locationService: locationService, userDefaults: userDefaults, bundledRegionsFilePath: bundledRegionsPath, apiPath: regionsAPIPath, delegate: testDelegate)
+
+        waitUntil { done in
+            self.testDelegate.updatedRegionsListCallbacks.append {
+                expect(regionsService.regions.count) == 1
+                done()
+            }
+            regionsService.updateRegionsList()
+        }
+    }
+
     // MARK: - Persistence
 
     // It stores downloaded region data in user defaults when the regions property is set.


### PR DESCRIPTION
This change makes it easier to debug Regions changes by forcing the app to update its list of Regions from the server on every app launch. To turn it on:

1. Enable debug mode - Go to the More tab and tap on the app logo
2. Tap on Settings in the top right
3. Toggle the "Refresh regions on every launch" switch on