### PR TITLE
Clarify identity protocol usage in OBAListView

### DIFF
--- a/OBAKit/Bookmarks/BookmarksViewModel.swift
+++ b/OBAKit/Bookmarks/BookmarksViewModel.swift
@@ -29,6 +29,10 @@ struct BookmarkArrivalViewModel: OBAListViewItem {
     let regionIdentifier: Int
     let stopID: StopID
 
+    var id: String {
+        return "bookmark=\(bookmarkID),region=\(regionIdentifier),stopID=\(stopID)"
+    }
+
     let isFavorite: Bool
     let sortOrder: Int
 
@@ -78,9 +82,14 @@ struct BookmarkArrivalViewModel: OBAListViewItem {
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(bookmarkID)
-        hasher.combine(regionIdentifier)
-        hasher.combine(stopID)
+        hasher.combine(id)
+        hasher.combine(name)
+        hasher.combine(isFavorite)
+        hasher.combine(sortOrder)
+        hasher.combine(routeShortName)
+        hasher.combine(tripHeadsign)
+        hasher.combine(routeID)
+        hasher.combine(arrivalDepartures)
     }
 
     static func == (lhs: BookmarkArrivalViewModel, rhs: BookmarkArrivalViewModel) -> Bool {

--- a/OBAKit/Controls/ListView/Helpers/OBAListViewDebug.swift
+++ b/OBAKit/Controls/ListView/Helpers/OBAListViewDebug.swift
@@ -43,6 +43,7 @@ struct DEBUG_Person: OBAListViewItem {
 
 /// Sample view model, using a custom cell for its content.
 struct DEBUG_CustomContent: OBAListViewItem {
+    var id: UUID = UUID()
     var text: String
     var onSelectAction: OBAListViewAction<DEBUG_CustomContent>?
 

--- a/OBAKit/Controls/ListView/ViewModels/OBAListViewSection.swift
+++ b/OBAKit/Controls/ListView/ViewModels/OBAListViewSection.swift
@@ -16,7 +16,7 @@ import UIKit
 /// ## Collapsible sections
 /// Set `collapseState` to a non-`nil` value. Note, `OBAListView` will also need to have collapsible
 /// section implementation to properly function.
-public struct OBAListViewSection: Hashable {
+public struct OBAListViewSection: Hashable, Identifiable {
     public typealias ID = String
     public enum CollapseState {
         case collapsed
@@ -91,6 +91,8 @@ public struct OBAListViewSection: Hashable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+        hasher.combine(title)
+        hasher.combine(contents)
     }
 
     public static func == (lhs: OBAListViewSection, rhs: OBAListViewSection) -> Bool {

--- a/OBAKit/Recent/RecentStopViewModels.swift
+++ b/OBAKit/Recent/RecentStopViewModels.swift
@@ -15,7 +15,7 @@ struct StopViewModel: OBAListViewItem {
     let name: String
     let subtitle: String?
 
-    let stopID: Stop.ID
+    let id: Stop.ID
 
     var contentConfiguration: OBAContentConfiguration {
         return OBAListRowConfiguration(
@@ -34,18 +34,18 @@ struct StopViewModel: OBAListViewItem {
         self.name = stop.name
         self.subtitle = stop.subtitle
 
-        self.stopID = stop.id
+        self.id = stop.id
         self.onSelectAction = selectAction
         self.onDeleteAction = deleteAction
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(stopID)
+        hasher.combine(name)
+        hasher.combine(subtitle)
     }
 
     static func == (lhs: StopViewModel, rhs: StopViewModel) -> Bool {
-        return lhs.stopID == rhs.stopID &&
-            lhs.name == rhs.name &&
+        return lhs.name == rhs.name &&
             lhs.subtitle == rhs.subtitle
     }
 }
@@ -56,6 +56,8 @@ extension RecentStopsViewController {
         let deepLink: ArrivalDepartureDeepLink
 
         let title: String
+
+        var id: URL { alarm.url }
 
         var contentConfiguration: OBAContentConfiguration {
             return OBAListRowConfiguration(
@@ -80,11 +82,16 @@ extension RecentStopsViewController {
         }
 
         func hash(into hasher: inout Hasher) {
+            hasher.combine(id)
+            hasher.combine(title)
+            alarm.hash(into: &hasher)
             deepLink.hash(into: &hasher)
         }
 
         static func == (lhs: AlarmViewModel, rhs: AlarmViewModel) -> Bool {
-            return lhs.title == rhs.title
+            return lhs.alarm.isEqual(rhs.alarm) &&
+                lhs.deepLink.isEqual(rhs.deepLink) &&
+                lhs.title == rhs.title
         }
     }
 }

--- a/OBAKit/Reporting/ReportProblemViewController.swift
+++ b/OBAKit/Reporting/ReportProblemViewController.swift
@@ -118,7 +118,7 @@ class ReportProblemViewController: OperationController<DecodableOperation<RESTAP
     }
 
     func onSelectArrivalDeparture(_ arrivalDepartureItem: ArrivalDepartureItem) {
-        guard let arrDep = data?.arrivalsAndDepartures.first(where: { $0.id == arrivalDepartureItem.identifier }) else { return }
+        guard let arrDep = data?.arrivalsAndDepartures.first(where: { $0.id == arrivalDepartureItem.id }) else { return }
         let controller = VehicleProblemViewController(application: self.application, arrivalDeparture: arrDep)
         self.navigationController?.pushViewController(controller, animated: true)
     }

--- a/OBAKit/Stops/NearbyStopsViewController.swift
+++ b/OBAKit/Stops/NearbyStopsViewController.swift
@@ -120,7 +120,7 @@ class NearbyStopsViewController: OperationController<DecodableOperation<RESTAPIR
         }
 
         let tapHandler = { (vm: NearbyStopViewModel) -> Void in
-            self.application.viewRouter.navigateTo(stopID: vm.stopID, from: self)
+            self.application.viewRouter.navigateTo(stopID: vm.id, from: self)
         }
 
         return directions.sorted(by: \.key).map { (direction, _) -> OBAListViewSection in
@@ -140,7 +140,7 @@ class NearbyStopsViewController: OperationController<DecodableOperation<RESTAPIR
 }
 
 struct NearbyStopViewModel: OBAListViewItem {
-    let stopID: String
+    let id: String
     let title: String
     let subtitle: String
 
@@ -153,13 +153,15 @@ struct NearbyStopViewModel: OBAListViewItem {
     init(stop: Stop, onSelectAction: @escaping OBAListViewAction<NearbyStopViewModel>) {
         self.onSelectAction = onSelectAction
 
-        self.stopID = stop.id
+        self.id = stop.id
         self.title = Formatters.formattedTitle(stop: stop)
         self.subtitle = Formatters.formattedRoutes(stop.routes)
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(stopID)
+        hasher.combine(id)
+        hasher.combine(title)
+        hasher.combine(subtitle)
     }
 
     static func == (lhs: NearbyStopViewModel, rhs: NearbyStopViewModel) -> Bool {

--- a/OBAKit/Stops/Sections/StopArrival/StopArrivalItem.swift
+++ b/OBAKit/Stops/Sections/StopArrival/StopArrivalItem.swift
@@ -22,7 +22,7 @@ struct ArrivalDepartureItem: OBAListViewItem {
     var bookmarkAction: OBAListViewAction<ArrivalDepartureItem>?
     var shareAction: OBAListViewAction<ArrivalDepartureItem>?
 
-    let identifier: String
+    let id: String
     let routeID: RouteID
     let stopID: StopID
 
@@ -96,7 +96,7 @@ struct ArrivalDepartureItem: OBAListViewItem {
          bookmarkAction: OBAListViewAction<ArrivalDepartureItem>? = nil,
          shareAction: OBAListViewAction<ArrivalDepartureItem>? = nil) {
 
-        self.identifier = arrivalDeparture.id
+        self.id = arrivalDeparture.id
         self.routeID = arrivalDeparture.routeID
         self.stopID = arrivalDeparture.stopID
         self.name = arrivalDeparture.routeAndHeadsign
@@ -121,12 +121,17 @@ struct ArrivalDepartureItem: OBAListViewItem {
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(identifier)
+        hasher.combine(id)
+        hasher.combine(routeID)
+        hasher.combine(stopID)
+        hasher.combine(name)
+        hasher.combine(scheduledDate)
+        hasher.combine(scheduleStatus)
+        hasher.combine(temporalState)
     }
 
     static func == (lhs: ArrivalDepartureItem, rhs: ArrivalDepartureItem) -> Bool {
-        return lhs.identifier == rhs.identifier &&
-            lhs.routeID == rhs.routeID &&
+        return lhs.routeID == rhs.routeID &&
             lhs.stopID == rhs.stopID &&
             lhs.name == rhs.name &&
             lhs.scheduledDate == rhs.scheduledDate &&

--- a/OBAKit/Stops/StopHeaderController.swift
+++ b/OBAKit/Stops/StopHeaderController.swift
@@ -12,6 +12,7 @@ import OBAKitCore
 
 // MARK: - StopHeaderSection
 struct StopHeaderItem: OBAListViewItem {
+    var id: String { stop.id }
     var contentConfiguration: OBAContentConfiguration {
         return StopHeaderContentConfiguration(stop: stop, application: application)
     }
@@ -26,7 +27,8 @@ struct StopHeaderItem: OBAListViewItem {
     var application: Application
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(stop.id)
+        hasher.combine(id)
+        stop.hash(into: &hasher)
     }
 
     static func == (lhs: StopHeaderItem, rhs: StopHeaderItem) -> Bool {

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -544,7 +544,7 @@ public class StopViewController: UIViewController,
     //           revisit this decision.
 
     func arrivalDeparture(forViewModel viewModel: ArrivalDepartureItem) -> ArrivalDeparture? {
-        return stopArrivals?.arrivalsAndDepartures.filter({ $0.id == viewModel.identifier }).first
+        return stopArrivals?.arrivalsAndDepartures.filter({ $0.id == viewModel.id }).first
     }
 
     // MARK: Actions
@@ -601,7 +601,7 @@ public class StopViewController: UIViewController,
 
     private func performPreviewStopArrival(_ viewModel: ArrivalDepartureItem) {
         if let previewingVC = self.previewingVC,
-           previewingVC.identifier == viewModel.identifier,
+           previewingVC.identifier == viewModel.id,
            let tripVC = previewingVC.vc as? TripViewController {
             tripVC.exitPreviewMode()
             application.viewRouter.navigate(to: tripVC, from: self)

--- a/OBAKit/Trip/AdjacentTripController.swift
+++ b/OBAKit/Trip/AdjacentTripController.swift
@@ -28,6 +28,8 @@ struct AdjacentTripRowConfiguration: OBAContentConfiguration {
 }
 
 struct AdjacentTripItem: OBAListViewItem {
+    var id: String { trip.id }
+
     let order: AdjacentTripOrder
     let trip: Trip
     var onSelectAction: OBAListViewAction<AdjacentTripItem>?
@@ -37,7 +39,9 @@ struct AdjacentTripItem: OBAListViewItem {
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(trip.id)
+        hasher.combine(id)
+        hasher.combine(order)
+        hasher.combine(trip)
     }
 
     static func == (lhs: AdjacentTripItem, rhs: AdjacentTripItem) -> Bool {

--- a/OBAKit/Trip/TripStopListItem.swift
+++ b/OBAKit/Trip/TripStopListItem.swift
@@ -22,6 +22,8 @@ struct TripStopListItemRowConfiguration: OBAContentConfiguration {
 }
 
 struct TripStopViewModel: OBAListViewItem {
+    var id: String { stop.id }
+
     var contentConfiguration: OBAContentConfiguration {
         return TripStopListItemRowConfiguration(viewModel: self)
     }
@@ -79,7 +81,12 @@ struct TripStopViewModel: OBAListViewItem {
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(stop.id)
+        hasher.combine(id)
+        hasher.combine(isCurrentVehicleLocation)
+        hasher.combine(isUserDestination)
+        hasher.combine(title)
+        hasher.combine(date)
+        hasher.combine(routeType)
     }
 
     static func == (lhs: TripStopViewModel, rhs: TripStopViewModel) -> Bool {


### PR DESCRIPTION
I've been struggling to understand the true purpose of Hashable and Equatable, but I think I have it figured out now.
For the record, AFAIK `NSDiffableDataSource` only cares about `Hashable`. Hashable is supposed to be the object's "identity", but I have been misinterpreting this as "stable identity". As such, I believe this was the root cause of #359.

This is an overview of my findings, and the new roles in OBAListView:
- The `Hashable` protocol requires a `hash` method. This is needed for `NSDiffableDataSource`, which is the "identity" of the model. It should be a combination of *all values, including the identifier*.
- The `Identifiable` protocol requires an `id` property. It is currently not in use, reserved for future item identification functionality. This value is the "stable identity" (e.g. `stopID`) of the model.
- The `Equatable` protocol requires a `==` method to compare equality. It is currently not in use, reserved for future item diffing functionality. This should compare the values between both subjects, excluding its identifier.

## Changes
- Added documentation guidance on Hashable, Equatable, and Identifiable purposes in OBAListViewItem
- Updated view models to reflect new identity guidance

Related: https://developer.apple.com/forums/thread/126742