### PR TITLE
Various tweaks

### DIFF
--- a/OBAKit/Alerts/AgencyAlertsViewController.swift
+++ b/OBAKit/Alerts/AgencyAlertsViewController.swift
@@ -150,4 +150,9 @@ class AgencyAlertsViewController: UIViewController,
     func items(for listView: OBAListView) -> [OBAListViewSection] {
         return listSections(agencyAlerts: alertsStore.agencyAlerts)
     }
+
+    func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
+        let regionName = application.currentRegion?.name
+        return .standard(.init(title: Strings.emptyAlertTitle, body: regionName))
+    }
 }

--- a/OBAKit/Controls/ListView/OBAListView.swift
+++ b/OBAKit/Controls/ListView/OBAListView.swift
@@ -246,9 +246,26 @@ public class OBAListView: UICollectionView, UICollectionViewDelegate {
     }
 
     fileprivate func trailingSwipeActions(for indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        guard let actions = itemForIndexPath(indexPath)?.trailingContextualActions else { return nil }
+        guard let item = itemForIndexPath(indexPath) else { return nil }
+        let contextualActions = item.trailingContextualActions ?? []
+        var swipeActions = contextualActions.map { $0.contextualAction }
 
-        let config = UISwipeActionsConfiguration(actions: actions.map { $0.contextualAction })
+        if let deleteAction = item.onDeleteAction {
+            // Hides "Delete" text if the cell is less than 64 units tall.
+            let cellSize = self.cellForItem(at: indexPath)?.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height ?? 0
+            let isCellCompact = cellSize < 64
+            let swipeActionText = isCellCompact ? nil : Strings.delete
+
+            let deleteAction =  UIContextualAction(style: .destructive, title: swipeActionText) { _, _, success in
+                deleteAction(item)
+                success(true)
+            }
+            deleteAction.image = Icons.delete
+
+            swipeActions.append(deleteAction)
+        }
+
+        let config = UISwipeActionsConfiguration(actions: swipeActions)
         config.performsFirstActionWithFullSwipe = false
 
         return config

--- a/OBAKit/Controls/ListView/Rows/Configurations/OBAImageViewConfiguration.swift
+++ b/OBAKit/Controls/ListView/Rows/Configurations/OBAImageViewConfiguration.swift
@@ -1,0 +1,36 @@
+//
+//  OBAImageViewConfiguration.swift
+//  OBAKit
+//
+//  Created by Alan Chu on 6/28/21.
+//
+
+import OBAKitCore
+
+/// A view model defining `UIListContentConfiguration.ImageProperties` properties.
+///
+/// Technical Note: This may be expanded in the future, as needed.
+public struct OBAImageViewConfiguration: Equatable {
+    public var tintColor: UIColor?
+    public var maximumSize: CGSize
+
+    // MARK: - Initializers
+    init(tintColor: UIColor? = ThemeColors.shared.brand, maximumSize: CGSize = .zero) {
+        self.tintColor = tintColor
+        self.maximumSize = maximumSize
+    }
+
+    static public func tinted(_ color: UIColor) -> Self {
+        return self.init(tintColor: color)
+    }
+
+    static public func maximumSize(squared: CGFloat) -> Self {
+        return self.init(maximumSize: CGSize(width: squared, height: squared))
+    }
+
+    // MARK: - Apply
+    func apply(to contentConfiguration: inout UIListContentConfiguration) {
+        contentConfiguration.imageProperties.tintColor = self.tintColor
+        contentConfiguration.imageProperties.maximumSize = self.maximumSize
+    }
+}

--- a/OBAKit/Controls/ListView/Rows/Configurations/OBALabelConfiguration.swift
+++ b/OBAKit/Controls/ListView/Rows/Configurations/OBALabelConfiguration.swift
@@ -1,0 +1,96 @@
+//
+//  OBALabelConfiguration.swift
+//  OBAKit
+//
+//  Created by Alan Chu on 6/28/21.
+//
+
+import Foundation
+
+/// A view model defining `UILabel` properties.
+///
+/// Technical Note: This may be expanded in the future, as needed.
+public struct OBALabelConfiguration: Hashable, Equatable {
+    var textColor: UIColor = .label
+
+    /// The number of lines when the content size is a standard size, aka `UITraitEnvironment.isAccessibility` is `false`.
+    var numberOfLines: Int = 0
+
+    /// The number of lines when the content size is an accessibility size, aka `UITraitEnvironment.isAccessibility` is `true`.
+    var accessibilityNumberOfLines: Int = 0
+
+    func applyToText(_ config: inout UIListContentConfiguration) {
+        config.textProperties.color = textColor
+        config.textProperties.numberOfLines = numberOfLines
+    }
+
+    func applyToSecondaryText(_ config: inout UIListContentConfiguration) {
+        config.secondaryTextProperties.color = textColor
+        config.secondaryTextProperties.numberOfLines = numberOfLines
+    }
+}
+
+extension UILabel {
+    /// A helper method for configuring a `UILabel` to use `OBALabelConfiguration`.
+    func configure(with config: OBALabelConfiguration) {
+        self.textColor = config.textColor
+        self.numberOfLines = isAccessibility ? config.accessibilityNumberOfLines : config.numberOfLines
+    }
+
+    func setText(_ text: OBAListRowConfiguration.LabelText?) {
+        if let text = text {
+            switch text {
+            case .string(let string):
+                self.text = string
+            case .attributed(let attributed):
+                self.attributedText = attributed
+            }
+        } else {
+            self.text = nil // setting text to nil also sets attributed text to nil in UILabel.
+        }
+    }
+}
+
+extension UIListContentConfiguration {
+    var labelText: OBAListRowConfiguration.LabelText? {
+        get {
+            if let text = text {
+                return .string(text)
+            } else if let attributedText = attributedText {
+                return .attributed(attributedText)
+            } else {
+                return nil
+            }
+        } set {
+            if let labelText = newValue {
+                switch labelText {
+                case .string(let string): self.text = string
+                case .attributed(let text): self.attributedText = text
+                }
+            } else {
+                self.secondaryText = nil
+            }
+        }
+    }
+
+    var secondaryLabelText: OBAListRowConfiguration.LabelText? {
+        get {
+            if let text = secondaryText {
+                return .string(text)
+            } else if let attributedText = secondaryAttributedText {
+                return .attributed(attributedText)
+            } else {
+                return nil
+            }
+        } set {
+            if let labelText = newValue {
+                switch labelText {
+                case .string(let string): self.secondaryText = string
+                case .attributed(let text): self.secondaryAttributedText = text
+                }
+            } else {
+                self.secondaryText = nil
+            }
+        }
+    }
+}

--- a/OBAKit/Controls/ListView/Rows/OBAListRowConfiguration.swift
+++ b/OBAKit/Controls/ListView/Rows/OBAListRowConfiguration.swift
@@ -12,7 +12,7 @@ import UIKit
 ///
 /// The `appearance` property governs what data may be shown. For example, the `default`
 /// appearance will gracefully ignore the `secondaryText` property since it only has one label view.
-public struct OBAListRowConfiguration: OBAContentConfiguration, Hashable, Equatable {
+public struct OBAListRowConfiguration: OBAContentConfiguration, Equatable {
     public enum Appearance {
         /// The default look of a list row.
         case `default`
@@ -70,6 +70,8 @@ public struct OBAListRowConfiguration: OBAContentConfiguration, Hashable, Equata
     public var formatters: Formatters?
 
     public var image: UIImage?
+    public var imageConfig: OBAImageViewConfiguration = .init()
+
     public var text: LabelText?
     public var secondaryText: LabelText?
 
@@ -93,10 +95,11 @@ public struct OBAListRowConfiguration: OBAContentConfiguration, Hashable, Equata
         }
 
         config.image = self.image
-        config.imageProperties.tintColor = ThemeColors.shared.brand
-        textConfig.applyToText(&config)
+        imageConfig.apply(to: &config)
 
         config.labelText = self.text
+        textConfig.applyToText(&config)
+
         config.secondaryLabelText = self.secondaryText
         secondaryTextConfig.applyToSecondaryText(&config)
 
@@ -111,94 +114,6 @@ public struct OBAListRowConfiguration: OBAContentConfiguration, Hashable, Equata
             return 0
         case .default, .subtitle, .value:
             return 44.0
-        }
-    }
-}
-
-/// A view model defining `UILabel` properties.
-/// 
-/// Technical Note: This may be expanded in the future, as needed.
-public struct OBALabelConfiguration: Hashable, Equatable {
-    var textColor: UIColor = .label
-
-    /// The number of lines when the content size is a standard size, aka `UITraitEnvironment.isAccessibility` is `false`.
-    var numberOfLines: Int = 0
-
-    /// The number of lines when the content size is an accessibility size, aka `UITraitEnvironment.isAccessibility` is `true`.
-    var accessibilityNumberOfLines: Int = 0
-
-    func applyToText(_ config: inout UIListContentConfiguration) {
-        config.textProperties.color = textColor
-        config.textProperties.numberOfLines = numberOfLines
-    }
-
-    func applyToSecondaryText(_ config: inout UIListContentConfiguration) {
-        config.secondaryTextProperties.color = textColor
-        config.secondaryTextProperties.numberOfLines = numberOfLines
-    }
-}
-
-extension UILabel {
-    /// A helper method for configuring a `UILabel` to use `OBALabelConfiguration`.
-    func configure(with config: OBALabelConfiguration) {
-        self.textColor = config.textColor
-        self.numberOfLines = isAccessibility ? config.accessibilityNumberOfLines : config.numberOfLines
-    }
-
-    func setText(_ text: OBAListRowConfiguration.LabelText?) {
-        if let text = text {
-            switch text {
-            case .string(let string):
-                self.text = string
-            case .attributed(let attributed):
-                self.attributedText = attributed
-            }
-        } else {
-            self.text = nil // setting text to nil also sets attributed text to nil in UILabel.
-        }
-    }
-}
-
-extension UIListContentConfiguration {
-    var labelText: OBAListRowConfiguration.LabelText? {
-        get {
-            if let text = text {
-                return .string(text)
-            } else if let attributedText = attributedText {
-                return .attributed(attributedText)
-            } else {
-                return nil
-            }
-        } set {
-            if let labelText = newValue {
-                switch labelText {
-                case .string(let string): self.text = string
-                case .attributed(let text): self.attributedText = text
-                }
-            } else {
-                self.secondaryText = nil
-            }
-        }
-    }
-
-    var secondaryLabelText: OBAListRowConfiguration.LabelText? {
-        get {
-            if let text = secondaryText {
-                return .string(text)
-            } else if let attributedText = secondaryAttributedText {
-                return .attributed(attributedText)
-            } else {
-                return nil
-            }
-        } set {
-            if let labelText = newValue {
-                switch labelText {
-                case .string(let string): self.secondaryText = string
-                case .attributed(let text): self.secondaryAttributedText = text
-                }
-            } else {
-                self.secondaryText = nil
-            }
         }
     }
 }

--- a/OBAKit/Controls/ListView/Rows/OBAListSectionConfiguration.swift
+++ b/OBAKit/Controls/ListView/Rows/OBAListSectionConfiguration.swift
@@ -11,16 +11,22 @@ public struct OBAListSectionConfiguration: Equatable {
         case insetGrouped
     }
 
-    public let appearance: ListAppearance
+    public var appearance: ListAppearance
 
-    public init(appearance: ListAppearance = .plain) {
+    /// Note, per `UICollectionLayoutListConfiguration`, a value of `nil` means that the configuration uses the system background color.
+    public var backgroundColor: UIColor?
+
+    // MARK: - Initializers
+    public init(appearance: ListAppearance = .plain, backgroundColor: UIColor? = nil) {
         self.appearance = appearance
+        self.backgroundColor = nil
     }
 
     static public func appearance(_ appearance: ListAppearance) -> Self {
         return .init(appearance: appearance)
     }
 
+    // MARK: - UIKit
     func listConfiguration() -> UICollectionLayoutListConfiguration {
         let appearance: UICollectionLayoutListConfiguration.Appearance
         switch self.appearance {
@@ -28,6 +34,8 @@ public struct OBAListSectionConfiguration: Equatable {
         case .insetGrouped: appearance = .insetGrouped
         }
 
-        return .init(appearance: appearance)
+        var config = UICollectionLayoutListConfiguration(appearance: appearance)
+        config.backgroundColor = self.backgroundColor
+        return config
     }
 }

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -391,8 +391,8 @@ public class MapViewController: UIViewController,
 
     private lazy var mapPanelController = MapFloatingPanelController(application: application, mapRegionManager: application.mapRegionManager, delegate: self)
 
-    func mapPanelController(_ controller: MapFloatingPanelController, didSelectStop stop: Stop) {
-        show(stop: stop)
+    func mapPanelController(_ controller: MapFloatingPanelController, didSelectStop stopID: Stop.ID) {
+        application.viewRouter.navigateTo(stopID: stopID, from: self)
     }
 
     func mapPanelControllerDisplaySearch(_ controller: MapFloatingPanelController) {

--- a/OBAKit/Recent/RecentStopViewModels.swift
+++ b/OBAKit/Recent/RecentStopViewModels.swift
@@ -16,13 +16,21 @@ struct StopViewModel: OBAListViewItem {
     let subtitle: String?
 
     let id: Stop.ID
+    let routeType: Route.RouteType
 
+    // Hide icon if there is only one type of route in the list
     var configuration: OBAListViewItemConfiguration {
-        return .custom(OBAListRowConfiguration(
-                        text: .string(name),
-                        secondaryText: .string(subtitle),
-                        appearance: .subtitle,
-                        accessoryType: .disclosureIndicator))
+        let transportIcon = Icons.transportIcon(from: routeType)
+        var config = OBAListRowConfiguration(
+            image: transportIcon,
+            text: .string(name),
+            secondaryText: .string(subtitle),
+            appearance: .subtitle,
+            accessoryType: .disclosureIndicator)
+        config.imageConfig.tintColor = .label
+        config.imageConfig.maximumSize = CGSize(width: 24, height: 24)
+
+        return .custom(config)
     }
 
     let onSelectAction: OBAListViewAction<StopViewModel>?
@@ -33,6 +41,7 @@ struct StopViewModel: OBAListViewItem {
          onDelete deleteAction: OBAListViewAction<StopViewModel>?) {
         self.name = stop.nameWithLocalizedDirectionAbbreviation
         self.subtitle = stop.subtitle
+        self.routeType = stop.prioritizedRouteTypeForDisplay
 
         self.id = stop.id
         self.onSelectAction = selectAction

--- a/OBAKit/Recent/RecentStopViewModels.swift
+++ b/OBAKit/Recent/RecentStopViewModels.swift
@@ -37,9 +37,11 @@ struct StopViewModel: OBAListViewItem {
     let onDeleteAction: OBAListViewAction<StopViewModel>?
 
     init(withStop stop: Stop,
+         showDirectionInTitle: Bool = false,
          onSelect selectAction: OBAListViewAction<StopViewModel>?,
          onDelete deleteAction: OBAListViewAction<StopViewModel>?) {
-        self.name = stop.nameWithLocalizedDirectionAbbreviation
+
+        self.name = showDirectionInTitle ? stop.nameWithLocalizedDirectionAbbreviation : stop.name
         self.subtitle = stop.subtitle
         self.routeType = stop.prioritizedRouteTypeForDisplay
 

--- a/OBAKit/Recent/RecentStopViewModels.swift
+++ b/OBAKit/Recent/RecentStopViewModels.swift
@@ -16,7 +16,6 @@ struct StopViewModel: OBAListViewItem {
     let subtitle: String?
 
     let id: Stop.ID
-    let stop: Stop
 
     var configuration: OBAListViewItemConfiguration {
         return .custom(OBAListRowConfiguration(
@@ -32,8 +31,7 @@ struct StopViewModel: OBAListViewItem {
     init(withStop stop: Stop,
          onSelect selectAction: OBAListViewAction<StopViewModel>?,
          onDelete deleteAction: OBAListViewAction<StopViewModel>?) {
-        self.stop = stop
-        self.name = stop.name
+        self.name = stop.nameWithLocalizedDirectionAbbreviation
         self.subtitle = stop.subtitle
 
         self.id = stop.id
@@ -42,18 +40,11 @@ struct StopViewModel: OBAListViewItem {
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(stop)
         hasher.combine(id)
-        hasher.combine(name)
-        hasher.combine(subtitle)
     }
 
     static func == (lhs: StopViewModel, rhs: StopViewModel) -> Bool {
-        return
-            lhs.id == rhs.id &&
-            lhs.name == rhs.name &&
-            lhs.subtitle == rhs.subtitle &&
-            lhs.stop.isEqual(rhs.stop)
+        return lhs.id == rhs.id
     }
 }
 

--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -11,7 +11,8 @@ import OBAKitCore
 /// Provides an interface to browse recently-viewed information, mostly `Stop`s.
 public class RecentStopsViewController: UIViewController,
     AppContext,
-    OBAListViewDataSource {
+    OBAListViewDataSource,
+    OBAListViewContextMenuDelegate {
 
     let application: Application
 
@@ -44,6 +45,7 @@ public class RecentStopsViewController: UIViewController,
 
         view.backgroundColor = ThemeColors.shared.systemBackground
         view.addSubview(listView)
+        listView.contextMenuDelegate = self
         listView.pinToSuperview(.edges)
     }
 
@@ -162,5 +164,24 @@ public class RecentStopsViewController: UIViewController,
         }
 
         return .standard(.init(title: title, body: subtitle, buttonConfig: button))
+    }
+
+    fileprivate var currentPreviewingViewController: UIViewController?
+    public func contextMenu(_ listView: OBAListView, for item: AnyOBAListViewItem) -> OBAListViewMenuActions? {
+        guard let stopViewModel = item.as(StopViewModel.self) else { return nil }
+
+        let previewProvider: OBAListViewMenuActions.PreviewProvider = { [unowned self] () -> UIViewController? in
+            let stopVC = StopViewController(application: self.application, stopID: stopViewModel.id)
+            self.currentPreviewingViewController = stopVC
+            return stopVC
+        }
+
+        let commitPreviewAction: VoidBlock = { [unowned self] in
+            guard let vc = self.currentPreviewingViewController else { return }
+            (vc as? Previewable)?.exitPreviewMode()
+            self.application.viewRouter.navigate(to: vc, from: self)
+        }
+
+        return OBAListViewMenuActions(previewProvider: previewProvider, performPreviewAction: commitPreviewAction, contextMenuProvider: nil)
     }
 }

--- a/OBAKit/Recent/RecentStopsViewController.swift
+++ b/OBAKit/Recent/RecentStopsViewController.swift
@@ -128,17 +128,17 @@ public class RecentStopsViewController: UIViewController,
         }
 
         let rows = stops.map { stop -> StopViewModel in
-            let onSelect = { (viewModel: StopViewModel) -> Void in
-                self.application.viewRouter.navigateTo(stop: stop, from: self)
+            let onSelect: OBAListViewAction<StopViewModel> = { [unowned self] viewModel in
+                self.application.viewRouter.navigateTo(stopID: viewModel.id, from: self)
             }
 
-            let onDelete = { (viewModel: StopViewModel) -> Void in
+            let onDelete: OBAListViewAction<StopViewModel> = { [unowned self] viewModel in
                 self.application.userDataStore.delete(recentStop: stop)
                 self.listView.applyData(animated: true)
             }
 
             return StopViewModel(withStop: stop, onSelect: onSelect, onDelete: onDelete)
-        }
+        }.uniqued
 
         let title = application.userDataStore.alarms.count > 0 ? Strings.recentStops : nil
         return OBAListViewSection(id: "recent_stops", title: title, contents: rows)

--- a/OBAKit/Routes/RouteStopsViewController.swift
+++ b/OBAKit/Routes/RouteStopsViewController.swift
@@ -46,7 +46,7 @@ class RouteStopsViewController: VisualEffectViewController,
         super.viewDidLoad()
 
         titleView.titleLabel.text = stopsForRoute.route.shortName
-        titleView.subtitleLabel.text = stopsForRoute.route.longName
+        titleView.subtitleLabel.text = stopsForRoute.route.longName ?? stopsForRoute.route.agency.name
         titleView.closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
 
         listView.obaDataSource = self

--- a/OBAKit/Stops/NearbyStopsViewController.swift
+++ b/OBAKit/Stops/NearbyStopsViewController.swift
@@ -119,13 +119,13 @@ class NearbyStopsViewController: OperationController<DecodableOperation<RESTAPIR
             directions[stop.direction] = list
         }
 
-        let tapHandler = { (vm: NearbyStopViewModel) -> Void in
+        let tapHandler = { [unowned self] (vm: StopViewModel) -> Void in
             self.application.viewRouter.navigateTo(stopID: vm.id, from: self)
         }
 
         return directions.sorted(by: \.key).map { (direction, _) -> OBAListViewSection in
             let stops = directions[direction] ?? []
-            let cells = stops.map { NearbyStopViewModel(stop: $0, onSelectAction: tapHandler) }
+            let cells = stops.map { StopViewModel(withStop: $0, showDirectionInTitle: false, onSelect: tapHandler, onDelete: nil) }
             let header = Formatters.adjectiveFormOfCardinalDirection(direction) ?? ""
             return OBAListViewSection(id: "\(direction.rawValue)", title: header, contents: cells)
         }
@@ -136,35 +136,5 @@ class NearbyStopsViewController: OperationController<DecodableOperation<RESTAPIR
         let body = OBALoc("nearby_stops_controller.empty_set.body", value: "There are no other stops in the vicinity.", comment: "Body for the empty set indicator on the Nearby Stops controller.")
 
         return .standard(.init(title: title, body: body))
-    }
-}
-
-struct NearbyStopViewModel: OBAListViewItem {
-    let id: String
-    let title: String
-    let subtitle: String?
-
-    let onSelectAction: OBAListViewAction<NearbyStopViewModel>?
-
-    var configuration: OBAListViewItemConfiguration {
-        return .custom(OBAListRowConfiguration(text: .string(title), secondaryText: .string(subtitle), appearance: .subtitle, accessoryType: .disclosureIndicator))
-    }
-
-    init(stop: Stop, onSelectAction: @escaping OBAListViewAction<NearbyStopViewModel>) {
-        self.onSelectAction = onSelectAction
-
-        self.id = stop.id
-        self.title = Formatters.formattedTitle(stop: stop)
-        self.subtitle = Formatters.formattedRoutes(stop.routes)
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-        hasher.combine(title)
-        hasher.combine(subtitle)
-    }
-
-    static func == (lhs: NearbyStopViewModel, rhs: NearbyStopViewModel) -> Bool {
-        return lhs.title == rhs.title && lhs.subtitle == rhs.subtitle
     }
 }

--- a/OBAKit/Stops/NearbyStopsViewController.swift
+++ b/OBAKit/Stops/NearbyStopsViewController.swift
@@ -142,7 +142,7 @@ class NearbyStopsViewController: OperationController<DecodableOperation<RESTAPIR
 struct NearbyStopViewModel: OBAListViewItem {
     let id: String
     let title: String
-    let subtitle: String
+    let subtitle: String?
 
     let onSelectAction: OBAListViewAction<NearbyStopViewModel>?
 

--- a/OBAKit/Stops/Sections/StopArrival/StopArrivalCell.swift
+++ b/OBAKit/Stops/Sections/StopArrival/StopArrivalCell.swift
@@ -26,7 +26,6 @@ final class StopArrivalCell: OBAListViewCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        contentView.backgroundColor = ThemeColors.shared.systemBackground
 
         stopArrivalView = StopArrivalView.autolayoutNew()
         stopArrivalView.backgroundColor = .clear

--- a/OBAKit/Trip/TripSegmentView.swift
+++ b/OBAKit/Trip/TripSegmentView.swift
@@ -141,3 +141,63 @@ class TripSegmentView: UIView {
         image.draw(in: frame.insetBy(dx: imageInset, dy: imageInset))
     }
 }
+
+#if DEBUG
+import SwiftUI
+import OBAKitCore
+
+struct TripSegmentView_Previews: PreviewProvider {
+    private static let standardTripSegmentView: some View = {
+        UIViewPreview { TripSegmentView() }
+    }()
+
+    private static let userTripSegmentView: some View = { () -> UIViewPreview in
+        let view = TripSegmentView()
+        view.setDestinationStatus(user: true, vehicle: false)
+        return UIViewPreview { view }
+    }()
+
+    private static let vehicleTripSegmentView: some View = { () -> UIViewPreview in
+        let view = TripSegmentView()
+        view.setDestinationStatus(user: false, vehicle: true)
+        return UIViewPreview { view }
+    }()
+
+    private static let userVehicleTripSegmentView: some View = { () -> UIViewPreview in
+        let view = TripSegmentView()
+        view.setDestinationStatus(user: true, vehicle: true)
+        return UIViewPreview { view }
+    }()
+
+    private static let width: CGFloat = 64
+    private static let height: CGFloat = 44
+
+    static var previews: some View {
+        HStack {
+            VStack {
+                standardTripSegmentView
+                    .frame(width: width, height: height, alignment: .center)
+                Text("Standard")
+            }
+            VStack {
+                userTripSegmentView
+                    .frame(width: width, height: height, alignment: .center)
+                Text("User")
+            }
+            VStack {
+                vehicleTripSegmentView
+                    .frame(width: width, height: height, alignment: .center)
+                Text("Vehicle")
+            }
+            VStack {
+                userVehicleTripSegmentView
+                    .frame(width: width, height: height, alignment: .center)
+                Text("User & Vehicle")
+            }
+        }
+        .previewLayout(.sizeThatFits)
+        .padding()
+    }
+}
+
+#endif

--- a/OBAKit/Trip/TripSegmentView.swift
+++ b/OBAKit/Trip/TripSegmentView.swift
@@ -147,26 +147,26 @@ import SwiftUI
 import OBAKitCore
 
 struct TripSegmentView_Previews: PreviewProvider {
-    private static let standardTripSegmentView: some View = {
-        UIViewPreview { TripSegmentView() }
+    private static let standardTripSegmentView: TripSegmentView = {
+        return TripSegmentView()
     }()
 
-    private static let userTripSegmentView: some View = { () -> UIViewPreview in
+    private static let userTripSegmentView: TripSegmentView = {
         let view = TripSegmentView()
         view.setDestinationStatus(user: true, vehicle: false)
-        return UIViewPreview { view }
+        return view
     }()
 
-    private static let vehicleTripSegmentView: some View = { () -> UIViewPreview in
+    private static let vehicleTripSegmentView: TripSegmentView = {
         let view = TripSegmentView()
         view.setDestinationStatus(user: false, vehicle: true)
-        return UIViewPreview { view }
+        return view
     }()
 
-    private static let userVehicleTripSegmentView: some View = { () -> UIViewPreview in
+    private static let userVehicleTripSegmentView: TripSegmentView = {
         let view = TripSegmentView()
         view.setDestinationStatus(user: true, vehicle: true)
-        return UIViewPreview { view }
+        return view
     }()
 
     private static let width: CGFloat = 64
@@ -175,22 +175,22 @@ struct TripSegmentView_Previews: PreviewProvider {
     static var previews: some View {
         HStack {
             VStack {
-                standardTripSegmentView
+                UIViewPreview { standardTripSegmentView }
                     .frame(width: width, height: height, alignment: .center)
                 Text("Standard")
             }
             VStack {
-                userTripSegmentView
+                UIViewPreview { userTripSegmentView }
                     .frame(width: width, height: height, alignment: .center)
                 Text("User")
             }
             VStack {
-                vehicleTripSegmentView
+                UIViewPreview { vehicleTripSegmentView }
                     .frame(width: width, height: height, alignment: .center)
                 Text("Vehicle")
             }
             VStack {
-                userVehicleTripSegmentView
+                UIViewPreview { userVehicleTripSegmentView }
                     .frame(width: width, height: height, alignment: .center)
                 Text("User & Vehicle")
             }

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -338,7 +338,7 @@ class TripViewController: UIViewController,
                 self.routePolyline = polyline
                 self.mapView.addOverlay(polyline)
                 if !self.mapView.hasBeenTouched {
-                    self.mapView.visibleMapRect = self.mapView.mapRectThatFits(polyline.boundingMapRect, edgePadding: UIEdgeInsets(top: 60, left: 20, bottom: 60, right: 20))
+                    self.mapView.visibleMapRect = self.mapView.mapRectThatFits(polyline.boundingMapRect, edgePadding: UIEdgeInsets(top: 60, left: 20, bottom: 128, right: 20))
                 }
             }
         }
@@ -384,9 +384,6 @@ class TripViewController: UIViewController,
         guard !skipNextStopTimeHighlight else { return }
 
         func mapViewAnnotationSelectionComplete() {
-            if !self.mapView.hasBeenTouched {
-                self.mapView.setCenter(stopTime.stop.coordinate, animated: true)
-            }
             self.tripDetailsController.highlightStopInList(stopTime.stop)
         }
 

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -281,7 +281,7 @@ class TripViewController: UIViewController,
                 self.currentTripStatus = response.entry.status
 
                 // In cases where TripStatus.coordinates is (0,0), we don't want to show it.
-                var annotationsToShow = self.mapView.annotations
+                var annotationsToShow = self.mapView.annotations.filter { !($0 is MKUserLocation) }
                 annotationsToShow.removeAll(where: { $0.coordinate.isNullIsland })
 
                 if !self.mapView.hasBeenTouched {

--- a/OBAKitCore/Models/REST/References/Stop.swift
+++ b/OBAKitCore/Models/REST/References/Stop.swift
@@ -96,6 +96,16 @@ public class Stop: NSObject, Identifiable, Codable, HasReferences {
     /// A human-readable name for this stop.
     public let name: String
 
+    /// A localized name for this stop including the direction, if available.
+    /// Example: "E Pine St & 15th Ave (W)" for a westbound bus stop.
+    public var nameWithLocalizedDirectionAbbreviation: String {
+        if let direction = Formatters.directionAbbreviation(direction) {
+            return "\(name) (\(direction))"
+        } else {
+            return name
+        }
+    }
+
     /// A list of route IDs served by this stop.
     ///
     /// Route IDs correspond to values in References.

--- a/OBAKitCore/Strings/Strings.swift
+++ b/OBAKitCore/Strings/Strings.swift
@@ -84,4 +84,6 @@ public class Strings: NSObject {
     public static let emptyBookmarkTitle = OBALoc("common.empty_bookmark_set.title", value: "No Bookmarks", comment: "Title for the bookmark empty set indicator.")
 
     public static let emptyBookmarkBody = OBALoc("common.empty_bookmark_set.body", value: "Add a bookmark for a stop or trip to easily access it here.", comment: "Body for the bookmark empty set indicator.")
+
+    public static let emptyAlertTitle = OBALoc("common.empty_alert_set.title", value: "No Alerts", comment: "Title for the alert empty set indicator.")
 }

--- a/OBAKitCore/UI/DepartureTimeBadge.swift
+++ b/OBAKitCore/UI/DepartureTimeBadge.swift
@@ -59,6 +59,7 @@ public class DepartureTimeBadge: UILabel, ArrivalDepartureDrivenUI {
 
         textAlignment = .center
         font = UIFont.preferredFont(forTextStyle: .headline)
+        adjustsFontSizeToFitWidth = true
 
         layer.backgroundColor = UIColor.clear.cgColor
         layer.masksToBounds = true
@@ -98,3 +99,62 @@ public class DepartureTimeBadge: UILabel, ArrivalDepartureDrivenUI {
         }
     }
 }
+
+#if DEBUG
+import SwiftUI
+
+struct DepartureTimeBadge_Previews: PreviewProvider {
+    private static let nowBadge: DepartureTimeBadge = {
+        let badge = DepartureTimeBadge()
+        badge.configure(.preview("NOW", color: .red))
+        return badge
+    }()
+
+    private static let fiveMinutesBadge: DepartureTimeBadge = {
+        let badge = DepartureTimeBadge()
+        badge.configure(.preview("5m", color: .blue))
+        return badge
+    }()
+
+    private static let ninetyNineMinutesBadge: DepartureTimeBadge = {
+        let badge = DepartureTimeBadge()
+        badge.configure(.preview("99m", color: .gray))
+        return badge
+    }()
+
+    private static let nineNineNineChineseBadge: DepartureTimeBadge = {
+        let badge = DepartureTimeBadge()
+        badge.configure(.preview("999分", color: .blue))
+        return badge
+    }()
+
+    // For fixing #354 -- TodayView “NOW” is ellipsized
+    fileprivate static let constrainedFrameStack: UIStackView = {
+        NSLayoutConstraint.activate([
+            nowBadge.widthAnchor.constraint(equalToConstant: 48),
+            fiveMinutesBadge.widthAnchor.constraint(equalToConstant: 48),
+            ninetyNineMinutesBadge.widthAnchor.constraint(equalToConstant: 48),
+            nineNineNineChineseBadge.widthAnchor.constraint(equalToConstant: 48)
+        ])
+
+        let stack = UIStackView.stack(arrangedSubviews: [nowBadge, fiveMinutesBadge, ninetyNineMinutesBadge, nineNineNineChineseBadge])
+        NSLayoutConstraint.activate([stack.heightAnchor.constraint(equalToConstant: 24)])
+        return stack
+    }()
+
+    static var previews: some View {
+        UIViewPreview {
+            constrainedFrameStack
+        }
+        .previewLayout(.sizeThatFits)
+        .padding()
+    }
+}
+
+extension DepartureTimeBadge.Configuration {
+    static func preview(_ text: String, color: UIColor) -> Self {
+        return .init(accessibilityLabel: "", displayText: text, backgroundColor: color.cgColor)
+    }
+}
+
+#endif

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -508,8 +508,13 @@ public class Formatters: NSObject {
     ///
     /// - Parameter routes: An array of `Route`s from which the string will be generated.
     /// - Returns: A human-readable list of the passed-in `Route`
-    public class func formattedRoutes(_ routes: [Route]) -> String {
-        let routeNames = routes.map { $0.shortName }.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    public class func formattedRoutes(_ routes: [Route]) -> String? {
+        let routeNames = routes
+            .map { $0.shortName }
+            .filter { !$0.isEmpty }     // Some agencies may not provide a shortName (i.e. Washington State Ferries in Puget Sound)
+            .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+        guard routeNames.isEmpty == false else { return nil }
+
         let fmt = OBALoc("formatters.routes_label_fmt", value: "Routes: %@", comment: "A format string used to denote the list of routes served by this stop. e.g. 'Routes: 10, 12, 49'")
         return String(format: fmt, routeNames.joined(separator: ", "))
     }


### PR DESCRIPTION
## App-wide
- Allow DepartureTimeBadge to resize font size to fit width (fixes #354)
- Add context menus to `StopViewModel` instances (`MapFloatingPanelController` and `RecentStopsViewController`)

## TripViewController
- Don’t need to include user’s location when previewing TripViewController (fixes #366)
- Remove center on stop when user selects annotation

## DRY `StopViewModel`
- Remove `RecentStopViewModel`
- Removes reference to `Stop` instance in favor of the Stop's ID.
- Add display route icons to stop rows
- Don’t show stop subtitle if the routes are all empty strings ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-27 at 10 40 40](https://user-images.githubusercontent.com/22162410/124362214-76fb2c00-dbe8-11eb-881c-2ba86f3657ab.png)

## Other
- Add empty data set for Alerts ![Simulator Screen Shot - iPhone 12 Pro - 2021-07-01 at 00 21 34](https://user-images.githubusercontent.com/22162410/124362211-75316880-dbe8-11eb-9be6-fbf4ed441537.png)
- Add delete contextual action to OBAListView (a #391 regression)

## Tech
- Adds `OBAImageViewConfiguration` for configuring a UIListContentConfiguration's image view
- Adds SwiftUI view previews to `TripSegmentView` ![image](https://user-images.githubusercontent.com/22162410/124362248-ae69d880-dbe8-11eb-9182-3abfed99a763.png)