### PR TITLE
Resizable StopHeaderController

### DIFF
--- a/OBAKit/Mapping/MapSnapshotter.swift
+++ b/OBAKit/Mapping/MapSnapshotter.swift
@@ -41,6 +41,22 @@ class MapSnapshotter: NSObject {
         options.region = MapHelpers.coordinateRegionWith(center: stop.coordinate, zoomLevel: zoomLevel, size: size)
         options.scale = scale
         options.mapType = mapType
+
+        // POIs to show are public services and first/last-mile transportation (car rental & car parking)
+        options.pointOfInterestFilter = MKPointOfInterestFilter(including: [
+            .airport,
+            .beach,
+            .carRental,
+            .hospital,
+            .library,
+            .nationalPark,
+            .park,
+            .parking,
+            .school,
+            .stadium,
+            .university
+        ])
+
         options.traitCollection = traitCollection
 
         return options

--- a/OBAKit/Stops/Sections/Generic/ErrorCaptionItem.swift
+++ b/OBAKit/Stops/Sections/Generic/ErrorCaptionItem.swift
@@ -1,0 +1,31 @@
+//
+//  ErrorCaptionItem.swift
+//  OBAKit
+//
+//  Created by Alan Chu on 7/12/21.
+//
+
+import UIKit
+
+struct ErrorCaptionItem: OBAListViewItem {
+    var configuration: OBAListViewItemConfiguration {
+        var config = UIListContentConfiguration.cell()
+        config.textProperties.font = .preferredFont(forTextStyle: .body)
+        config.textProperties.color = .label
+        config.text = self.text
+
+        config.image = UIImage(systemName: "exclamationmark.triangle.fill")
+        config.imageProperties.tintColor = .systemOrange
+        config.imageProperties.preferredSymbolConfiguration = .init(textStyle: .headline)
+
+        return .list(config, [])
+    }
+
+    var id: UUID
+    var text: String
+
+    init(id: UUID = UUID(), error: Error) {
+        self.id = id
+        self.text = error.localizedDescription
+    }
+}

--- a/OBAKit/Stops/Sections/Generic/MessageButtonItem.swift
+++ b/OBAKit/Stops/Sections/Generic/MessageButtonItem.swift
@@ -8,11 +8,10 @@
 import UIKit
 import OBAKitCore
 
-/// Displays a button with optional footer text and error text.
-/// With optional support for showing activity indicator on selection (see `showActivityIndicatorOnSelect` property).
+/// Displays a button with optional support for showing activity indicator on selection (see `showActivityIndicatorOnSelect` property).
 struct MessageButtonItem: OBAListViewItem {
     var configuration: OBAListViewItemConfiguration {
-        return .custom(MessageButtonContentConfiguration(errorText: errorText, buttonText: buttonText, footerText: footerText, showActivityIndicatorOnSelect: showActivityIndicatorOnSelect, onTapAction: {
+        return .custom(MessageButtonContentConfiguration(buttonText: buttonText, showActivityIndicatorOnSelect: showActivityIndicatorOnSelect, onTapAction: {
             onSelectAction?(self)
         }))
     }
@@ -26,36 +25,28 @@ struct MessageButtonItem: OBAListViewItem {
     var onSelectAction: OBAListViewAction<MessageButtonItem>?
 
     var id: String
-    var errorText: String?
     var buttonText: String
-    var footerText: String?
 
     /// When the user selects this item, the button will be replaced by an activity indicator.
     var showActivityIndicatorOnSelect: Bool
 
     init(id: String,
-         error: Error? = nil,
          buttonText: String,
-         footerText: String? = nil,
          showActivityIndicatorOnSelect: Bool,
          onSelectAction: OBAListViewAction<MessageButtonItem>? = nil) {
 
         self.id = id
-        self.errorText = error?.localizedDescription
         self.buttonText = buttonText
-        self.footerText = footerText
         self.showActivityIndicatorOnSelect = showActivityIndicatorOnSelect
         self.onSelectAction = onSelectAction
     }
 
     init(asLoadMoreButtonWithID id: String,
-         error: Error? = nil,
-         footerText: String? = nil,
          showActivityIndicatorOnSelect: Bool,
          onSelectAction: OBAListViewAction<MessageButtonItem>? = nil) {
 
         let loadMoreLocalized = OBALoc("stop_controller.load_more_button", value: "Load More", comment: "Load More button")
-        self.init(id: id, error: error, buttonText: loadMoreLocalized, footerText: footerText, showActivityIndicatorOnSelect: showActivityIndicatorOnSelect, onSelectAction: onSelectAction)
+        self.init(id: id, buttonText: loadMoreLocalized, showActivityIndicatorOnSelect: showActivityIndicatorOnSelect, onSelectAction: onSelectAction)
     }
 
     func hash(into hasher: inout Hasher) {
@@ -64,9 +55,7 @@ struct MessageButtonItem: OBAListViewItem {
 
     static func == (lhs: MessageButtonItem, rhs: MessageButtonItem) -> Bool {
         return lhs.id == rhs.id &&
-            lhs.errorText == rhs.errorText &&
             lhs.buttonText == rhs.buttonText &&
-            lhs.footerText == rhs.footerText &&
             lhs.showActivityIndicatorOnSelect == rhs.showActivityIndicatorOnSelect
     }
 }
@@ -77,29 +66,13 @@ struct MessageButtonContentConfiguration: OBAContentConfiguration {
         return MessageButtonCell.self
     }
 
-    var errorText: String?
     var buttonText: String
-    var footerText: String?
     var showActivityIndicatorOnSelect: Bool
 
     var onTapAction: VoidBlock?
 }
 
 final class MessageButtonCell: OBAListViewCell {
-    // MARK: - UI
-    private lazy var errorLabel: UILabel = {
-        let label: PaddingLabel = .obaLabel(font: .preferredFont(forTextStyle: .body), textColor: ThemeColors.shared.label)
-        label.translatesAutoresizingMaskIntoConstraints = true
-        label.textAlignment = .center
-        label.backgroundColor = UIColor.red.withAlphaComponent(0.25)
-        label.insets = UIEdgeInsets(top: ThemeMetrics.padding,
-                                    left: ThemeMetrics.padding,
-                                    bottom: ThemeMetrics.padding,
-                                    right: ThemeMetrics.padding)
-        label.cornerRadius = 8
-        return label
-    }()
-
     lazy var button: ActivityIndicatedButton = {
         let button = ActivityIndicatedButton()
         button.translatesAutoresizingMaskIntoConstraints = true
@@ -108,29 +81,13 @@ final class MessageButtonCell: OBAListViewCell {
         return button
     }()
 
-    private lazy var footerLabel: UILabel = {
-        let label: UILabel = .obaLabel(font: .preferredFont(forTextStyle: .footnote), textColor: ThemeColors.shared.secondaryLabel)
-        label.textAlignment = .center
-        return label
-    }()
-
-    private lazy var stack: UIStackView = {
-        let stack = UIStackView.stack(axis: .vertical,
-                                      distribution: .fill,
-                                      alignment: .center,
-                                      arrangedSubviews: [button, footerLabel])
-        stack.spacing = ThemeMetrics.padding
-        stack.setCompressionResistance(horizontal: nil, vertical: .required)
-        return stack
-    }()
-
     var showActivityIndicatorOnSelect: Bool = false
     var onTapAction: VoidBlock?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        contentView.addSubview(stack)
+        contentView.addSubview(button)
 
         self.showsLargeContentViewer = true
         self.addInteraction(UILargeContentViewerInteraction())
@@ -145,7 +102,7 @@ final class MessageButtonCell: OBAListViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        stack.pinToSuperview(.layoutMargins)
+        button.pinToSuperview(.layoutMargins)
     }
 
     override func prepareForReuse() {
@@ -164,20 +121,6 @@ final class MessageButtonCell: OBAListViewCell {
 
     override func apply(_ config: OBAContentConfiguration) {
         guard let config = config as? MessageButtonContentConfiguration else { return }
-
-        // If there is an error, add the error label to the stack view.
-        // If there isn't an error, remove error label from stack view.
-        if let errorText = config.errorText, !errorText.isEmpty {
-            if !stack.arrangedSubviews.contains(errorLabel) {
-                stack.insertArrangedSubview(errorLabel, at: 0)
-            }
-        } else if stack.arrangedSubviews.contains(errorLabel) {
-            stack.removeArrangedSubview(errorLabel)
-            errorLabel.removeFromSuperview()
-        }
-
-        errorLabel.text = config.errorText
-        footerLabel.text = config.footerText
 
         largeContentTitle = config.buttonText
 

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -812,10 +812,7 @@ public class StopViewController: UIViewController,
     }
 
     fileprivate var dataAttributionSection: OBAListViewSection {
-        let agencies = self.stop!.routes
-            .compactMap { $0.agency.name }
-            .uniqued
-            .joined(separator: ", ")
+        let agencies = Formatters.formattedAgenciesForRoutes(self.stop!.routes)
 
         let dataAttributionStringFormat = OBALoc("stop_controller.data_attribution_format", value: "Data provided by %@", comment: "A string listing the data providers (agencies) for this stop's data. It contains one or more providers separated by commas.")
         let dataAttribution = FootnoteItem(text: String(format: dataAttributionStringFormat, agencies))

--- a/OBAKit/Stops/StopViewController.swift
+++ b/OBAKit/Stops/StopViewController.swift
@@ -803,12 +803,20 @@ public class StopViewController: UIViewController,
         let afterTime = Date().addingTimeInterval(Double(minutesAfter) * 60.0)
         let footerText = application.formatters.formattedDateRange(from: beforeTime, to: afterTime)
 
-        let item = MessageButtonItem(asLoadMoreButtonWithID: "load_more_item", error: operationError, footerText: footerText, showActivityIndicatorOnSelect: true) { [weak self] _ in
+        var items: [AnyOBAListViewItem] = []
+
+        if let error = operationError {
+            items.append(ErrorCaptionItem(error: error).typeErased)
+        }
+
+        let loadMoreButton = MessageButtonItem(asLoadMoreButtonWithID: "load_more_item", showActivityIndicatorOnSelect: true) { [weak self] _ in
             self?.shouldScrollToBottomOfArrivalsDeparuresOnDataLoad = true
             self?.loadMoreDepartures()
         }
+        items.append(loadMoreButton.typeErased)
+        items.append(FootnoteItem(text: footerText).typeErased)
 
-        return listViewSection(for: .loadMoreButton, title: nil, items: [item])
+        return listViewSection(for: .loadMoreButton, title: nil, items: items)
     }
 
     fileprivate var dataAttributionSection: OBAListViewSection {

--- a/OBAKitCore/Utilities/Formatters.swift
+++ b/OBAKitCore/Utilities/Formatters.swift
@@ -507,7 +507,7 @@ public class Formatters: NSObject {
     /// For example: "Routes: 10, 12, 49".
     ///
     /// - Parameter routes: An array of `Route`s from which the string will be generated.
-    /// - Returns: A human-readable list of the passed-in `Route`
+    /// - Returns: A human-readable list of the passed-in `Route`s.
     public class func formattedRoutes(_ routes: [Route]) -> String? {
         let routeNames = routes
             .map { $0.shortName }
@@ -517,6 +517,20 @@ public class Formatters: NSObject {
 
         let fmt = OBALoc("formatters.routes_label_fmt", value: "Routes: %@", comment: "A format string used to denote the list of routes served by this stop. e.g. 'Routes: 10, 12, 49'")
         return String(format: fmt, routeNames.joined(separator: ", "))
+    }
+
+    /// Generates an alphabetical-ordered, formatted, human readable unique list of agencies.
+    ///
+    /// For example: "Community Transit, Sound Transit".
+    ///
+    /// - Parameter routes: An array of `Route`s from which the string will be generated.
+    /// - Returns: A human-readable list of the passed-in `Route`s.
+    public class func formattedAgenciesForRoutes(_ routes: [Route]) -> String {
+        return routes
+            .compactMap { $0.agency.name }
+            .uniqued
+            .sorted()
+            .joined(separator: ", ")
     }
 
     /// Returns an adjective form of the passed-in cardinal direction. For example `n` -> `Northbound`


### PR DESCRIPTION
Fixes weird autolayout in StopViewController and makes the header resizable.
If there is no route text in the header, then display the agency instead.

| Lots of routes (taller header) | No routes (displays agency) | Separate items for each element in LoadMore section (new error message design) |
| -- | -- | -- |
| ![](https://user-images.githubusercontent.com/22162410/125319448-9fbda880-e2ef-11eb-968a-f32b10def2ca.png) | ![](https://user-images.githubusercontent.com/22162410/125319492-a8ae7a00-e2ef-11eb-9d64-3aa13de712c1.png) | ![ ](https://user-images.githubusercontent.com/22162410/125319497-aba96a80-e2ef-11eb-9426-e3775b217591.png) |

Fixes #415