### PR TITLE
Add custom voiceover actions to control floating panel position

### DIFF
--- a/OBAKit/Controls/FloatingPanel/OBAFloatingPanelController.swift
+++ b/OBAKit/Controls/FloatingPanel/OBAFloatingPanelController.swift
@@ -1,0 +1,79 @@
+//
+//  OBAFloatingPanelController.swift
+//  OBAKit
+//
+//  Created by Alan Chu on 8/3/21.
+//
+
+import FloatingPanel
+
+/// A subclass of `FloatingPanelController` with additional accessibility features.
+class OBAFloatingPanelController: FloatingPanelController {
+    override init(delegate: FloatingPanelControllerDelegate?) {
+        super.init(delegate: delegate)
+
+        surfaceView.grabberHandle.accessibilityLabel = OBALoc("floating_panel.controller.accessibility_label", value: "Card controller", comment: "A voiceover title describing the 'grabber' for controlling the visibility of a card.")
+
+        let expandName = OBALoc("floating_panel.controller.expand_action_name", value: "Expand", comment: "A voiceover title describing the action to expand the visibility of a card.")
+        let collapseName = OBALoc("floating_panel.controller.collapse_action_name", value: "Collapse", comment: "A voiceover title describing the action to minimize (or collapse) the visibility of a card.")
+        let expandAction = UIAccessibilityCustomAction(name: expandName, target: self, selector: #selector(accessibilityActionExpandPanel))
+        let collapseAction = UIAccessibilityCustomAction(name: collapseName, target: self, selector: #selector(accessibilityActionCollapsePanel))
+
+        surfaceView.grabberHandle.accessibilityCustomActions = [expandAction, collapseAction]
+        surfaceView.grabberHandle.isAccessibilityElement = true
+        updateAccessibilityValue()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    private func updateAccessibilityValue() {
+        let accessibilityValue: String?
+        switch self.position {
+        case .full:
+            accessibilityValue = OBALoc("floating_panel.controller.position.full", value: "Full screen", comment: "A voiceover title describing that the card's visibility is taking up the full screen.")
+        case .half:
+            accessibilityValue = OBALoc("floating_panel.controller.position.half", value: "Half screen", comment: "A voiceover title describing that the card's visibility is taking up half of the screen.")
+        case .tip:
+            accessibilityValue = OBALoc("floating_panel.controller.position.minimized", value: "Minimized", comment: "A voiceover title describing that the card's visibility taking up the minimum amount of screen.")
+        case .hidden:
+            accessibilityValue = nil
+        }
+
+        surfaceView.grabberHandle.accessibilityValue = accessibilityValue
+    }
+
+    @objc private func accessibilityActionExpandPanel() -> Bool {
+        let availableAnchors = self.layout.supportedPositions.sorted(by: \.rawValue)
+        guard let anchor = availableAnchors.firstIndex(of: self.position),
+              anchor != 0       // Enum value of `0` is equivalent to `full`.
+        else { return false }
+
+        self.move(to: availableAnchors[anchor - 1], animated: true, completion: { [weak self] in
+            self?.updateAccessibilityValue()
+        })
+
+        return true
+    }
+
+    @objc private func accessibilityActionCollapsePanel() -> Bool {
+        let availableAnchors = self.layout.supportedPositions.sorted(by: \.rawValue)
+        guard let anchor = availableAnchors.firstIndex(of: self.position),
+              anchor != availableAnchors.count - 1
+        else { return false }
+
+        self.move(to: availableAnchors[anchor + 1], animated: true, completion: { [weak self] in
+            self?.updateAccessibilityValue()
+        })
+
+        return true
+    }
+
+    // Unable to override because this version of FloatingPanel is non-open (`open` keyword).
+    // Newer versions of FloatingPanel have `open` implementions of FloatingPanelController.
+//    override func move(to: FloatingPanelPosition, animated: Bool, completion: (() -> Void)? = nil) {
+//        super.move(to: to, animated: animated, completion: completion)
+//        self.updateAccessibilityValue()
+//    }
+}

--- a/OBAKit/Mapping/MapViewController.swift
+++ b/OBAKit/Mapping/MapViewController.swift
@@ -337,8 +337,8 @@ public class MapViewController: UIViewController,
     }
 
     /// The floating panel controller, which displays a drawer at the bottom of the map.
-    private lazy var floatingPanel: FloatingPanelController = {
-        let panel = FloatingPanelController(delegate: self)
+    private lazy var floatingPanel: OBAFloatingPanelController = {
+        let panel = OBAFloatingPanelController(delegate: self)
         panel.isRemovalInteractionEnabled = false
         panel.surfaceView.cornerRadius = ThemeMetrics.cornerRadius
         panel.surfaceView.backgroundColor = .clear

--- a/OBAKit/Trip/TripViewController.swift
+++ b/OBAKit/Trip/TripViewController.swift
@@ -181,8 +181,8 @@ class TripViewController: UIViewController,
     )
 
     /// The floating panel controller, which displays a drawer at the bottom of the map.
-    private lazy var floatingPanel: FloatingPanelController = {
-        let panel = FloatingPanelController(delegate: self)
+    private lazy var floatingPanel: OBAFloatingPanelController = {
+        let panel = OBAFloatingPanelController(delegate: self)
         panel.isRemovalInteractionEnabled = false
         panel.surfaceView.cornerRadius = ThemeMetrics.cornerRadius
         panel.contentMode = .fitToBounds


### PR DESCRIPTION
Fixes #429.
- When the panel changes positions via Voiceover, the accessibility value updates which causes Voiceover to explain the new value (i.e. from 'full' to 'half') while maintaining interaction context.
- The actions will increment/decrement thru all available positions and audibly notify the user if the action cannot be completed (i.e. if the panel is already 'full screen', but they keep activating the 'expand' action).

At some point, I plan to PR this feature upstream to the floatingpanel repo.

## Demo on device (w/ sound)
https://user-images.githubusercontent.com/22162410/128148004-8ac67afa-7659-4f96-a0fc-6faa7e428625.mov

