### PR TITLE
Updates some text related to data migrations

### DIFF
--- a/OBAKit/Bookmarks/BookmarksViewController.swift
+++ b/OBAKit/Bookmarks/BookmarksViewController.swift
@@ -170,7 +170,11 @@ public class BookmarksViewController: UIViewController,
     }
 
     public func emptyData(for listView: OBAListView) -> OBAListView.EmptyData? {
-        return .standard(.init(title: Strings.emptyBookmarkTitle, body: Strings.emptyBookmarkBody))
+        let body = application.hasDataToMigrate ?
+            Strings.emptyBookmarkBodyWithPendingMigration :
+            Strings.emptyBookmarkBody
+
+        return .standard(.init(title: Strings.emptyBookmarkTitle, body: body))
     }
 
     // MARK: - Bookmark Actions

--- a/OBAKit/Strings/en.lproj/Localizable.strings
+++ b/OBAKit/Strings/en.lproj/Localizable.strings
@@ -103,6 +103,24 @@
 /* A button that says continue and don't show again. */
 "fare_payments.dont_show_again" = "Continue and Don't Show Again";
 
+/* A voiceover title describing the 'grabber' for controlling the visibility of a card. */
+"floating_panel.controller.accessibility_label" = "Card controller";
+
+/* A voiceover title describing the action to minimize (or collapse) the visibility of a card. */
+"floating_panel.controller.collapse_action_name" = "Collapse";
+
+/* A voiceover title describing the action to expand the visibility of a card. */
+"floating_panel.controller.expand_action_name" = "Expand";
+
+/* A voiceover title describing that the card's visibility is taking up the full screen. */
+"floating_panel.controller.position.full" = "Full screen";
+
+/* A voiceover title describing that the card's visibility is taking up half of the screen. */
+"floating_panel.controller.position.half" = "Half screen";
+
+/* A voiceover title describing that the card's visibility taking up the minimum amount of screen. */
+"floating_panel.controller.position.minimized" = "Minimized";
+
 /* This button rejects the application's request to see the user's location. */
 "location_permission_bulletin.buttons.deny_permission" = "Maybe Later";
 
@@ -579,6 +597,12 @@
 
 /* Shown on the map when the user taps on a vehicle to indicate we don't know the vehicle's ID. */
 "trip_status_annotation.vehicle_id_unavailable" = "Vehicle ID Unavailable";
+
+/* Voiceover text explaining that this stop is the user's destination */
+"trip_stop.user_destination.accessibility_label" = "Your destination";
+
+/* Voiceover text explaining that the vehicle is currently at this stop */
+"trip_stop.vehicle_location.accessibility_label" = "Vehicle is here";
 
 /* Suggested invocation phrase for Siri Shortcut */
 "user_activity_builder.show_me_my_bus" = "Show me my bus";

--- a/OBAKitCore/Strings/Strings.swift
+++ b/OBAKitCore/Strings/Strings.swift
@@ -49,7 +49,7 @@ public class Strings: NSObject {
 
     public static let migrateData = OBALoc("common.migrate_data", value: "Migrate Data", comment: "A title or command for upgrading data from older versions of OBA.")
 
-    public static let migrateDataDescription = OBALoc("common.migrate_data_description", value: "Upgrade your recent stops and bookmarks to work with the latest version of the app.", comment: "An explanation about what the Migrate Data feature does.")
+    public static let migrateDataDescription = OBALoc("common.migrate_data_description", value: "Upgrade your recent stops and bookmarks to work with the latest version of the app. (Requires an internet connection.)", comment: "An explanation about what the Migrate Data feature does.")
 
     public static let more = OBALoc("common.more", value: "More", comment: "As in 'see more' or 'learn more'.")
 
@@ -84,6 +84,8 @@ public class Strings: NSObject {
     public static let emptyBookmarkTitle = OBALoc("common.empty_bookmark_set.title", value: "No Bookmarks", comment: "Title for the bookmark empty set indicator.")
 
     public static let emptyBookmarkBody = OBALoc("common.empty_bookmark_set.body", value: "Add a bookmark for a stop or trip to easily access it here.", comment: "Body for the bookmark empty set indicator.")
+
+    public static let emptyBookmarkBodyWithPendingMigration = OBALoc("common.empty_bookmark_set.body_with_pending_migration", value: "Go to the More tab > Settings > Migrate Data to see your bookmarks appear here.", comment: "Body for the bookmark empty set indicator when the user has a pending migration from the old version of the app.")
 
     public static let emptyAlertTitle = OBALoc("common.empty_alert_set.title", value: "No Alerts", comment: "Title for the alert empty set indicator.")
 }

--- a/OBAKitCore/Strings/en.lproj/Localizable.strings
+++ b/OBAKitCore/Strings/en.lproj/Localizable.strings
@@ -58,6 +58,9 @@
 /* Body for the bookmark empty set indicator. */
 "common.empty_bookmark_set.body" = "Add a bookmark for a stop or trip to easily access it here.";
 
+/* Body for the bookmark empty set indicator when the user has a pending migration from the old version of the app. */
+"common.empty_bookmark_set.body_with_pending_migration" = "Go to the More tab > Settings > Migrate Data to see your bookmarks appear here.";
+
 /* Title for the bookmark empty set indicator. */
 "common.empty_bookmark_set.title" = "No Bookmarks";
 
@@ -80,7 +83,7 @@
 "common.migrate_data" = "Migrate Data";
 
 /* An explanation about what the Migrate Data feature does. */
-"common.migrate_data_description" = "Upgrade your recent stops and bookmarks to work with the latest version of the app.";
+"common.migrate_data_description" = "Upgrade your recent stops and bookmarks to work with the latest version of the app. (Requires an internet connection.)";
 
 /* As in 'see more' or 'learn more'. */
 "common.more" = "More";


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/OBAKit/issues/433 - Remind non-migrated users that bookmarks may already exist
Fixes https://github.com/OneBusAway/OBAKit/issues/432 - Add "needs internet" message to migration bulletin

Also extracts a few new strings that need to be localized.